### PR TITLE
refactor: Rename msgtype enums to capital case

### DIFF
--- a/src/olink/clientnode.h
+++ b/src/olink/clientnode.h
@@ -93,7 +93,7 @@ public:
 public: // IClientNode
     /**
      * link object source to remote node by name
-     * sends LINK message
+     * sends Link message
      */
     void linkRemote(std::string name) override;
     /**
@@ -104,13 +104,13 @@ public: // IClientNode
     /**
      * invokes a remote function by name using arguments.
      * Result is delivered using reply function.
-     * sends INVOKE message and registers a reply handler (INVOKE_REPLY)
+     * sends Invoke message and registers a reply handler (InvokeReply)
      */
     void invokeRemote(std::string name, json args=json{}, InvokeReplyFunc func=nullptr) override;
     /**
      * set remote property using name to value.
-     * sends SET_PROPERTY message.
-     * Changes will be distributed using PROPERTY_CHANGE message.
+     * sends SetProperty message.
+     * Changes will be distributed using PropertyChange message.
      */
     void setRemoteProperty(std::string name, json value) override;
     /**

--- a/src/olink/core/protocol.cpp
+++ b/src/olink/core/protocol.cpp
@@ -56,28 +56,28 @@ Protocol::Protocol(IProtocolListener *listener)
 json Protocol::linkMessage(std::string name)
 {
     return json::array(
-                { MsgType::LINK, name }
+                { MsgType::Link, name }
                 );
 }
 
 json Protocol::unlinkMessage(std::string name)
 {
     return json::array(
-                { MsgType::UNLINK, name }
+                { MsgType::Unlink, name }
                 );
 }
 
 json Protocol::initMessage(std::string name, json props)
 {
     return json::array(
-                { MsgType::INIT, name, props }
+                { MsgType::Init, name, props }
                 );
 }
 
 json Protocol::setPropertyMessage(std::string name, json value)
 {
     return json::array(
-                { MsgType::SET_PROPERTY, name, value }
+                { MsgType::SetProperty, name, value }
                 );
 
 }
@@ -85,35 +85,35 @@ json Protocol::setPropertyMessage(std::string name, json value)
 json Protocol::propertyChangeMessage(std::string name, json value)
 {
     return json::array(
-                { MsgType::PROPERTY_CHANGE, name, value }
+                { MsgType::PropertyChange, name, value }
                 );
 }
 
 json Protocol::invokeMessage(int requestId, std::string name, json args)
 {
     return json::array(
-                { MsgType::INVOKE, requestId, name, args }
+                { MsgType::Invoke, requestId, name, args }
                 );
 }
 
 json Protocol::invokeReplyMessage(int requestId, std::string name, json value)
 {
     return json::array(
-                { MsgType::INVOKE_REPLY, requestId, name, value }
+                { MsgType::InvokeReply, requestId, name, value }
                 );
 }
 
 json Protocol::signalMessage(std::string name, json args)
 {
     return json::array(
-                { MsgType::SIGNAL, name, args }
+                { MsgType::Signal, name, args }
                 );
 }
 
 json Protocol::errorMessage(MsgType msgType, int requestId, std::string error)
 {
     return json::array(
-                { MsgType::ERROR, msgType, requestId, error }
+                { MsgType::Error, msgType, requestId, error }
                 );
 }
 
@@ -132,55 +132,55 @@ bool Protocol::handleMessage(json msg) {
     }
     const int msgType = msg[0].get<int>();
     switch(msgType) {
-    case int(MsgType::LINK): {
+    case int(MsgType::Link): {
         const std::string name = msg[1].get<std::string>();
         listener()->handleLink(name);
         break;
     }
-    case int(MsgType::INIT): {
+    case int(MsgType::Init): {
         const std::string name = msg[1].get<std::string>();
         const json props = msg[2].get<json>();
         if(listener()) listener()->handleInit(name, props);
         break;
     }
-    case int(MsgType::UNLINK): {
+    case int(MsgType::Unlink): {
         const std::string name = msg[1].get<std::string>();
         if(listener()) listener()->handleUnlink(name);
         break;
     }
-    case int(MsgType::SET_PROPERTY): {
+    case int(MsgType::SetProperty): {
         const std::string name = msg[1].get<std::string>();
         const json value = msg[2].get<json>();
         if(listener()) listener()->handleSetProperty(name, value);
         break;
     }
-    case int(MsgType::PROPERTY_CHANGE): {
+    case int(MsgType::PropertyChange): {
         const std::string name = msg[1].get<std::string>();
         const json value = msg[2].get<json>();
         if(listener()) listener()->handlePropertyChange(name, value);
         break;
     }
-    case int(MsgType::INVOKE): {
+    case int(MsgType::Invoke): {
         const int id = msg[1].get<int>();
         const std::string name = msg[2].get<std::string>();
         const json args = msg[3].get<json>();
         if(listener()) listener()->handleInvoke(id, name, args);
         break;
     }
-    case int(MsgType::INVOKE_REPLY): {
+    case int(MsgType::InvokeReply): {
         const int id = msg[1].get<int>();
         const std::string name = msg[2].get<std::string>();
         const json value = msg[3].get<json>();
         listener()->handleInvokeReply(id, name, value);
         break;
     }
-    case int(MsgType::SIGNAL): {
+    case int(MsgType::Signal): {
         const std::string name = msg[1].get<std::string>();
         const json args = msg[2].get<json>();
         listener()->handleSignal(name, args);
         break;
     }
-    case int(MsgType::ERROR): {
+    case int(MsgType::Error): {
         const int msgType = msg[1].get<int>();
         const int requestId = msg[2].get<int>();
         const std::string error = msg[3].get<std::string>();

--- a/src/olink/core/types.cpp
+++ b/src/olink/core/types.cpp
@@ -106,15 +106,15 @@ std::string MessageConverter::toString(json j)
 
 std::string toString(MsgType type) {
     static std::map<MsgType, std::string> typeNames = {
-        { MsgType::LINK, "link" },
-        { MsgType::UNLINK, "unlink" },
-        { MsgType::INIT, "init" },
-        { MsgType::SET_PROPERTY, "property_change" },
-        { MsgType::PROPERTY_CHANGE, "signal_property_change" },
-        { MsgType::INVOKE, "invole" },
-        { MsgType::INVOKE_REPLY, "invoke_reply" },
-        { MsgType::SIGNAL, "signal" },
-        { MsgType::ERROR, "error"
+        { MsgType::Link, "link" },
+        { MsgType::Unlink, "unlink" },
+        { MsgType::Init, "init" },
+        { MsgType::SetProperty, "property_change" },
+        { MsgType::PropertyChange, "signal_property_change" },
+        { MsgType::Invoke, "invole" },
+        { MsgType::InvokeReply, "invoke_reply" },
+        { MsgType::Signal, "signal" },
+        { MsgType::Error, "error"
         },
     };
     auto result = typeNames.find(type);

--- a/src/olink/core/types.cpp
+++ b/src/olink/core/types.cpp
@@ -111,7 +111,7 @@ std::string toString(MsgType type) {
         { MsgType::Init, "init" },
         { MsgType::SetProperty, "property_change" },
         { MsgType::PropertyChange, "signal_property_change" },
-        { MsgType::Invoke, "invole" },
+        { MsgType::Invoke, "invoke" },
         { MsgType::InvokeReply, "invoke_reply" },
         { MsgType::Signal, "signal" },
         { MsgType::Error, "error"

--- a/src/olink/core/types.h
+++ b/src/olink/core/types.h
@@ -46,15 +46,15 @@ public:
 
 enum class MsgType : int
 {
-    LINK = 10,
-    INIT = 11,
-    UNLINK = 12,
-    SET_PROPERTY = 20,
-    PROPERTY_CHANGE = 21,
-    INVOKE = 30,
-    INVOKE_REPLY = 31,
-    SIGNAL = 40,
-    ERROR = 99,
+    Link = 10,
+    Init = 11,
+    Unlink = 12,
+    SetProperty = 20,
+    PropertyChange = 21,
+    Invoke = 30,
+    InvokeReply = 31,
+    Signal = 40,
+    Error = 99,
 };
 
 std::string toString(MsgType type);

--- a/src/olink/remotenode.h
+++ b/src/olink/remotenode.h
@@ -134,20 +134,20 @@ public: // source registry
     static void removeObjectSource(IObjectSource *source);
 public: // IMessagesListener interface
     /**
-     * handle LINK message from client
+     * handle Link message from client
      */
     void handleLink(std::string name) override;
     /**
-     * handle UNLINK message from client
+     * handle Unlink message from client
      */
     void handleUnlink(std::string name) override;
     /**
-     * handle SET_PROPERTY message from client
+     * handle SetProperty message from client
      */
     void handleSetProperty(std::string name, json value) override;
     /**
-     * handle INVOKE message form client.
-     * Calls the object source and returns the value using INVOKE_REPLY message
+     * handle Invoke message form client.
+     * Calls the object source and returns the value using InvokeReply message
      */
     void handleInvoke(int requestId, std::string name, json args) override;
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,4 +1,6 @@
+#if defined(__clang__)
 #pragma clang diagnostic ignored "-Wweak-vtables"
+#endif // __clang__
 
 #define CATCH_CONFIG_MAIN
 

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -21,7 +21,7 @@ TEST_CASE("protocol")
     int value = 1;
     json args = {1, 2};
     int requestId = 1;
-    MsgType msgType = MsgType::INVOKE;
+    MsgType msgType = MsgType::Invoke;
     std::string error = "failed";
 
     ConsoleLogger log;
@@ -33,55 +33,55 @@ TEST_CASE("protocol")
     remote.onLog(log.logFunc());
     SECTION("link") {
         json msg = Protocol::linkMessage(name);
-        REQUIRE(msg[0] == MsgType::LINK);
+        REQUIRE(msg[0] == MsgType::Link);
         REQUIRE(msg[1] == name);
     }
     SECTION("unlink") {
         json msg = Protocol::unlinkMessage(name);
-        REQUIRE(msg[0] == MsgType::UNLINK);
+        REQUIRE(msg[0] == MsgType::Unlink);
         REQUIRE(msg[1] == name);
     }
     SECTION("init") {
         json msg = Protocol::initMessage(name, props);
-        REQUIRE(msg[0] == MsgType::INIT);
+        REQUIRE(msg[0] == MsgType::Init);
         REQUIRE(msg[1] == name);
         REQUIRE(msg[2] == props);
     }
     SECTION("setProperty") {
         json msg = Protocol::setPropertyMessage(name, value);
-        REQUIRE(msg[0] == MsgType::SET_PROPERTY);
+        REQUIRE(msg[0] == MsgType::SetProperty);
         REQUIRE(msg[1] == name);
         REQUIRE(msg[2] == value);
     }
     SECTION("propertyChange") {
         json msg = Protocol::propertyChangeMessage(name, value);
-        REQUIRE(msg[0] == MsgType::PROPERTY_CHANGE);
+        REQUIRE(msg[0] == MsgType::PropertyChange);
         REQUIRE(msg[1] == name);
         REQUIRE(msg[2] == value);
     }
     SECTION("invoke") {
         json msg = Protocol::invokeMessage(requestId, name, args);
-        REQUIRE(msg[0] == MsgType::INVOKE);
+        REQUIRE(msg[0] == MsgType::Invoke);
         REQUIRE(msg[1] == requestId);
         REQUIRE(msg[2] == name);
         REQUIRE(msg[3] == args);
     }
     SECTION("invokeReply") {
         json msg = Protocol::invokeReplyMessage(requestId, name, value);
-        REQUIRE(msg[0] == MsgType::INVOKE_REPLY);
+        REQUIRE(msg[0] == MsgType::InvokeReply);
         REQUIRE(msg[1] == requestId);
         REQUIRE(msg[2] == name);
         REQUIRE(msg[3] == value);
     }
     SECTION("signal") {
         json msg = Protocol::signalMessage(name, args);
-        REQUIRE(msg[0] == MsgType::SIGNAL);
+        REQUIRE(msg[0] == MsgType::Signal);
         REQUIRE(msg[1] == name);
         REQUIRE(msg[2] == args);
     }
     SECTION("error") {
         json msg = Protocol::errorMessage(msgType, requestId, error);
-        REQUIRE(msg[0] == MsgType::ERROR);
+        REQUIRE(msg[0] == MsgType::Error);
         REQUIRE(msg[1] == msgType);
         REQUIRE(msg[2] == requestId);
         REQUIRE(msg[3] == error);


### PR DESCRIPTION
In order to avoid naming conflicts with macros we rename all enums from
upper to captial case.