### PR TITLE
fix(tests): Configure tests to be found by ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,13 @@
 cmake_minimum_required(VERSION 3.14)
+project(objectlink-core-cpp LANGUAGES CXX)
 
+include(CTest)
 option(BUILD_EXAMPLES "Build examples" FALSE)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 
-project(objectlink-core-cpp LANGUAGES CXX)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(SPDLOG_DEBUG_ON true)
 set(SPDLOG_TRACE_ON true)
 
+if(BUILD_TESTING)
+enable_testing()
+
 Include(FetchContent)
 
 find_package(Catch2 QUIET)
@@ -27,5 +30,7 @@ set(TEST_OLINK_SOURCES
 )
 
 add_executable(tst_olink ${TEST_OLINK_SOURCES})
+add_test(tst_olink tst_olink)
 target_link_libraries(tst_olink PRIVATE olink_core Catch2::Catch2)
 
+endif() # BUILD_TESTING


### PR DESCRIPTION
The ctest setup was not properly configured. Therefore ctest was not
able to find the tests previously and the ci never executed them.