### PR TITLE
make registry thread safe

### DIFF
--- a/examples/app/calcsink.cpp
+++ b/examples/app/calcsink.cpp
@@ -8,7 +8,6 @@ CalcSink::CalcSink(QObject *parent)
     : QObject(parent)
     , m_node(nullptr)
 {
-    m_node = QClientRegistry::getInstance().addSink(this);
 }
 
 CalcSink::~CalcSink() {

--- a/src/olink/clientregistry.cpp
+++ b/src/olink/clientregistry.cpp
@@ -1,84 +1,106 @@
 #include "clientregistry.h"
 #include "iobjectsink.h"
-#include "clientnode.h"
+#include "iclientnode.h"
 
 
 namespace ApiGear {
 namespace ObjectLink {
 
-void ClientRegistry::setNode(ClientNode& node, const std::string& objectId)
+void ClientRegistry::setNode(std::weak_ptr<IClientNode> node, const std::string& objectId)
 {
-    emitLog(LogLevel::Info, "ClientRegistry.setNode: " + objectId);
-    auto& foundEntry = entry(objectId);
-    if (foundEntry.node == nullptr){
-        foundEntry.node = &node;
-    } else {
-        emitLog(LogLevel::Warning, "Trying to set a client node for " + objectId + " but node is already set. Node was NOT changed.");
+
+    auto lockedNode = node.lock();
+    if (!lockedNode){
+        emitLog(LogLevel::Warning, "Trying to add node, but it is already gone. Node NOT added.");
+        return;
     }
+
+    emitLog(LogLevel::Info, "ClientRegistry.setNode: " + objectId);
+
+    std::unique_lock<std::mutex> lock(m_entriesMutex);
+    auto entryForObject = m_entries.find(objectId);
+    if (entryForObject == m_entries.end()){
+        auto newEntry = SinkToClientEntry();
+        newEntry.node = lockedNode;
+        m_entries[objectId] = newEntry;
+    } else if (entryForObject->second.node.lock() == nullptr){
+        entryForObject->second.node = node;
+    } else if (entryForObject->second.node.lock() != lockedNode){
+        lock.unlock();
+        emitLog(LogLevel::Warning, "Trying to set a client node for " + objectId + " but other node is already set. Node was NOT changed.");
+    } 
 }
 
-void ClientRegistry::unsetNode(ClientNode& node, const std::string& objectId)
+void ClientRegistry::unsetNode(const std::string& objectId)
 {
     emitLog(LogLevel::Info, "ClientRegistry.unsetNode: " + objectId);
+    std::unique_lock<std::mutex> lock(m_entriesMutex);
     auto foundEntry = m_entries.find(objectId);
-    if (foundEntry != m_entries.end() &&  foundEntry->second.node  == &node){
-        foundEntry->second.node = nullptr;
+    if (foundEntry != m_entries.end()){
+        foundEntry->second.node.reset();
     }
 }
 
-void ClientRegistry::addSink(IObjectSink& sink)
+void ClientRegistry::addSink(std::weak_ptr<IObjectSink> sink)
 {
-    const auto& objectId = sink.olinkObjectName();
+    auto lockedSink = sink.lock();
+    if (!lockedSink){
+        emitLog(LogLevel::Warning, "Trying to add sink object, but it is already gone. New object NOT added.");
+        return;
+    }
+
+    const auto& objectId = lockedSink->olinkObjectName();
     emitLog(LogLevel::Info, "ClientRegistry.addSink: " + objectId);
-    auto& entryForObject = entry(objectId);
-    if (entryForObject.sink == nullptr){
-        entryForObject.sink = &sink;
-    } else {
-        emitLog(LogLevel::Warning, "Trying to add object for " + objectId + " but object for this id is already registerd. New object NOT added.");
+    auto newEntry = SinkToClientEntry();
+    newEntry.sink = lockedSink;
+
+    std::unique_lock<std::mutex> lock(m_entriesMutex);
+    auto entryForObject = m_entries.find(objectId);
+    if (entryForObject == m_entries.end()){
+        m_entries[objectId] = newEntry;
+    }  else if (entryForObject->second.sink.lock() != lockedSink){
+        lock.unlock();
+        emitLog(LogLevel::Warning, "Trying to add object for " + objectId + " but object for this id is already registered. New object NOT added.");
     }
 }
 
 void ClientRegistry::removeSink(const std::string& objectId)
 {
     emitLog(LogLevel::Info, "ClientRegistry.removeSink: " + objectId);
-    removeEntry(objectId);
+    std::unique_lock<std::mutex> lock(m_entriesMutex);
+    auto entry = m_entries.find(objectId);
+    if (entry != m_entries.end()) {
+        m_entries.erase(entry);
+    }
 }
 
-IObjectSink* ClientRegistry::getSink(const std::string& objectId)
+std::weak_ptr<IObjectSink> ClientRegistry::getSink(const std::string& objectId)
 {
     emitLog(LogLevel::Info, "ClientRegistry.getSink: " + objectId);
-    return entry(objectId).sink;
+    std::unique_lock<std::mutex> lock(m_entriesMutex);
+    auto entryForObject = m_entries.find(objectId);
+    return entryForObject != m_entries.end() ? entryForObject->second.sink  : std::weak_ptr<IObjectSink>();
 }
 
-std::vector<std::string> ClientRegistry::getObjectIds(ClientNode& node)
+std::vector<std::string> ClientRegistry::getObjectIds(std::weak_ptr<IClientNode> node)
 {
     std::vector<std::string> sinks;
+    sinks.reserve(m_entries.size());
+    std::unique_lock<std::mutex> lock(m_entriesMutex);
     for (auto& entry : m_entries) {
-        if (entry.second.node == &node) {
+        if (entry.second.node.lock() == node.lock()) {
             sinks.push_back(entry.first);
         }
     }
     return sinks;
 }
 
-ClientNode* ClientRegistry::getNode(const std::string& objectId)
+std::weak_ptr<IClientNode> ClientRegistry::getNode(const std::string& objectId)
 {
     emitLog(LogLevel::Info, "ClientRegistry.getNode: " + objectId);
-    return entry(objectId).node;
-}
-
-ClientRegistry::SinkToClientEntry& ClientRegistry::entry(const std::string& objectId) {
-    if (m_entries.count(objectId) == 0) {
-        m_entries[objectId] = SinkToClientEntry();
-    }
-    return m_entries[objectId];
-}
-
-void ClientRegistry::removeEntry(const std::string& objectId)
-{
-    if (m_entries.count(objectId) > 0) {
-        m_entries.erase(objectId);
-    }
+    std::unique_lock<std::mutex> lock(m_entriesMutex);
+    auto entry = m_entries.find(objectId);
+    return entry != m_entries.end() ? entry->second.node : std::weak_ptr<IClientNode>();
 }
 
 }} //namespace ApiGear::ObjectLink

--- a/src/olink/iclientnode.h
+++ b/src/olink/iclientnode.h
@@ -18,6 +18,8 @@ public:
     virtual ~IClientNode() = default;
     /**
      * Sends a message to request linking this client with a service side.
+     * Use this function to link remote sinks and associate them with source through this node.
+     * After linking the sink will be able to receive messages from source through this node.
      * @param objectId. An identifier of an object, used to find source object on service side with a matching objectId.
      *   Typically contains the module name and the object name.
      */

--- a/tests/sinkobject.hpp
+++ b/tests/sinkobject.hpp
@@ -15,9 +15,7 @@ public:
         , m_registry(registry)
         , m_total(0)
         , m_ready(false)
-    {
-        m_registry.addSink(*this);
-    }
+    {}
     virtual ~CalcSink() override {
         m_registry.removeSink(olinkObjectName());
     }

--- a/tests/test_client_registry.cpp
+++ b/tests/test_client_registry.cpp
@@ -10,22 +10,23 @@
 TEST_CASE("client registry")
 {
     // Sink MOCK objects, that always return associated with them ids.
-    SinkObjectMock sink1, sink2;
+    auto sink1 = std::make_shared<SinkObjectMock>();
+    auto sink2 = std::make_shared<SinkObjectMock>();
     std::string sink1Id= "tests.sink1";
     std::string sink2Id= "tests.sink2";
-    ALLOW_CALL(sink1, olinkObjectName()).RETURN(sink1Id);
-    ALLOW_CALL(sink2, olinkObjectName()).RETURN(sink2Id);
+    ALLOW_CALL(*sink1, olinkObjectName()).RETURN(sink1Id);
+    ALLOW_CALL(*sink2, olinkObjectName()).RETURN(sink2Id);
     // Real node objects are necessary for the Client Registry
     // Node class in its destructor informs sink registered for it in registry that it was released.
-    ALLOW_CALL(sink1, olinkOnRelease());
-    ALLOW_CALL(sink2, olinkOnRelease());
+    ALLOW_CALL(*sink1, olinkOnRelease());
+    ALLOW_CALL(*sink2, olinkOnRelease());
 
     ApiGear::ObjectLink::ClientRegistry clientRegistry;
     clientRegistry.addSink(sink1);
 
     SECTION("Add object and set node for it") {
 
-        ApiGear::ObjectLink::ClientNode node1(clientRegistry);
+        auto node1 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
 
         std::vector<std::string> empty = { };
         REQUIRE(clientRegistry.getObjectIds(node1) == empty);
@@ -33,26 +34,27 @@ TEST_CASE("client registry")
         clientRegistry.setNode(node1, sink1Id);
         std::vector<std::string> expectedId = { sink1Id };
         REQUIRE(clientRegistry.getObjectIds(node1) == expectedId);
-        REQUIRE(clientRegistry.getSink(sink1Id) == &sink1);
-        REQUIRE(clientRegistry.getNode(sink1Id) == &node1);
+        REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
+        REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
      }
 
     SECTION("Sink can be added after setting node")
     {
-        ApiGear::ObjectLink::ClientNode node1(clientRegistry);
+        auto node1 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
 
         REQUIRE(clientRegistry.getObjectIds(node1).size() == 0);
         clientRegistry.setNode(node1, sink1Id);
         std::vector<std::string> expectedId = { sink1Id };
         REQUIRE(clientRegistry.getObjectIds(node1) == expectedId);
 
-        REQUIRE(clientRegistry.getSink(sink1Id) == &sink1);
-        REQUIRE(clientRegistry.getNode(sink1Id) == &node1);
+        REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
+        REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
     }
 
     SECTION("Node can be set many sinks")
     {
-        ApiGear::ObjectLink::ClientNode node1(clientRegistry), node2(clientRegistry);
+        auto node1 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
+        auto node2 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
         clientRegistry.addSink(sink2);
 
         REQUIRE(clientRegistry.getObjectIds(node1).size() == 0);
@@ -64,80 +66,64 @@ TEST_CASE("client registry")
         REQUIRE_THAT(clientRegistry.getObjectIds(node1), Catch::Matchers::UnorderedEquals(expectedIds));
 
         // For all ids we're getting same node
-        REQUIRE(clientRegistry.getNode(sink1Id) == &node1);
-        REQUIRE(clientRegistry.getNode(sink2Id) == &node1);
-        REQUIRE(clientRegistry.getNode(notExisitnigSinkId) == &node1);
+        REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
+        REQUIRE(clientRegistry.getNode(sink2Id).lock() == node1);
+        REQUIRE(clientRegistry.getNode(notExisitnigSinkId).lock() == node1);
         // For all ids we're getting added objects
-        REQUIRE(clientRegistry.getSink(sink1Id) == &sink1);
-        REQUIRE(clientRegistry.getSink(sink2Id) == &sink2);
-        REQUIRE(clientRegistry.getSink(notExisitnigSinkId) == nullptr);
+        REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
+        REQUIRE(clientRegistry.getSink(sink2Id).lock() == sink2);
+        REQUIRE(clientRegistry.getSink(notExisitnigSinkId).lock() == nullptr);
     }
 
     SECTION("Node can be changed for object only after unset.")
     {
-        ApiGear::ObjectLink::ClientNode node1(clientRegistry), node2(clientRegistry);
+        auto node1 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
+        auto node2 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
 
         clientRegistry.setNode(node1, sink1Id);
-        REQUIRE(clientRegistry.getNode(sink1Id) == &node1);
+        REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
 
         clientRegistry.setNode(node2, sink1Id);
         // Still node1 set for id
-        REQUIRE(clientRegistry.getNode(sink1Id) == &node1);
-        REQUIRE(clientRegistry.getSink(sink1Id) == &sink1);
+        REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
+        REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
 
-        clientRegistry.unsetNode(node1, sink1Id);
-        REQUIRE(clientRegistry.getNode(sink1Id) == nullptr);
-        REQUIRE(clientRegistry.getSink(sink1Id) == &sink1);
+        clientRegistry.unsetNode(sink1Id);
+        REQUIRE(clientRegistry.getNode(sink1Id).lock() == nullptr);
+        REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
 
         clientRegistry.setNode(node2, sink1Id);
         // Now node2 is set
-        REQUIRE(clientRegistry.getNode(sink1Id) == &node2);
-        REQUIRE(clientRegistry.getSink(sink1Id) == &sink1);
+        REQUIRE(clientRegistry.getNode(sink1Id).lock() == node2);
+        REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
     }
 
     SECTION("Object can be registered for same id only after removing older object with its node.")
     {
-        SinkObjectMock differentSinkForId1;
-        ALLOW_CALL(differentSinkForId1, olinkOnRelease());
-        ALLOW_CALL(differentSinkForId1, olinkObjectName()).RETURN(sink1Id);
+        auto differentSinkForId1 = std::make_shared<SinkObjectMock>();
+        ALLOW_CALL(*differentSinkForId1, olinkOnRelease());
+        ALLOW_CALL(*differentSinkForId1, olinkObjectName()).RETURN(sink1Id);
 
-        ApiGear::ObjectLink::ClientNode node1(clientRegistry);
+        auto node1 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
         clientRegistry.setNode(node1, sink1Id);
 
-        REQUIRE(clientRegistry.getSink(sink1Id) == &sink1);
-        REQUIRE(clientRegistry.getNode(sink1Id) == &node1);
+        REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
+        REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
 
         clientRegistry.addSink(differentSinkForId1);
         // Still sink1Id registered with a node1 for id
-        REQUIRE(clientRegistry.getNode(sink1Id) == &node1);
-        REQUIRE(clientRegistry.getSink(sink1Id) == &sink1);
+        REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
+        REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
 
         clientRegistry.removeSink(sink1Id);
-        REQUIRE(clientRegistry.getNode(sink1Id) == nullptr);
-        REQUIRE(clientRegistry.getSink(sink1Id) == nullptr);
+        REQUIRE(clientRegistry.getNode(sink1Id).lock() == nullptr);
+        REQUIRE(clientRegistry.getSink(sink1Id).lock() == nullptr);
 
         clientRegistry.addSink(differentSinkForId1);
 
         // Now differentSinkForId1 is set for id, but no node is assigned.
-        REQUIRE(clientRegistry.getNode(sink1Id) == nullptr);
-        REQUIRE(clientRegistry.getSink(sink1Id) == &differentSinkForId1);
-    }
-
-    SECTION("To unset node both, the node and id must match.")
-    {
-        ApiGear::ObjectLink::ClientNode node1(clientRegistry), node2(clientRegistry);
-        clientRegistry.setNode(node1, sink1Id);
-        REQUIRE(clientRegistry.getNode(sink1Id) == &node1);
-
-        // node is still set, the node doesn't match.
-        clientRegistry.unsetNode(node2, sink1Id);
-        REQUIRE(clientRegistry.getNode(sink1Id) == &node1);
-        // node is still set, the id doesn't match.
-        clientRegistry.unsetNode(node1, sink2Id);
-        REQUIRE(clientRegistry.getNode(sink1Id) == &node1);
-        // successful unset
-        clientRegistry.unsetNode(node1, sink1Id);
-        REQUIRE(clientRegistry.getNode(sink1Id) == nullptr);
+        REQUIRE(clientRegistry.getNode(sink1Id).lock() == nullptr);
+        REQUIRE(clientRegistry.getSink(sink1Id).lock() == differentSinkForId1);
     }
 
     SECTION("Removing not existing object doesn't crash")

--- a/tests/test_olink.cpp
+++ b/tests/test_olink.cpp
@@ -32,34 +32,34 @@ TEST_CASE("link")
     registry.addSource(source);
 
     // setup client
-    ClientNode client(clientRegistry);
-    client.onLog(ConsoleLogger::logFunc());
-    CalcSink sink(clientRegistry);
+    auto client = ClientNode::create(clientRegistry);
+    client->onLog(ConsoleLogger::logFunc());
+    auto sink = std::make_shared<CalcSink>(clientRegistry);
     clientRegistry.addSink(sink);
 
     WriteMessageFunc clientWriteFunc = [&remote](std::string msg) {
         remote->handleMessage(msg);
     };
-    client.onWrite(clientWriteFunc);
+    client->onWrite(clientWriteFunc);
 
     WriteMessageFunc sourceWriteFunc = [&client](std::string msg) {
-        client.handleMessage(msg);
+        client->handleMessage(msg);
     };
     remote->onWrite(sourceWriteFunc);
 
     SECTION("link ->, <- init") {
         // not initialized sink, with total=0
-        REQUIRE( sink.isReady() == false );
-        REQUIRE( sink.total() == 0);
+        REQUIRE( sink->isReady() == false );
+        REQUIRE( sink->total() == 0);
         // link sink with source
-        client.linkRemote("demo.Calc");
+        client->linkRemote("demo.Calc");
         // initialized sink with total=1
-        REQUIRE( sink.isReady() == true );
-        REQUIRE( sink.total() == 1);
+        REQUIRE( sink->isReady() == true );
+        REQUIRE( sink->total() == 1);
     }
 
     registry.removeSource(source->olinkObjectName());
-    clientRegistry.removeSink(sink.olinkObjectName());
+    clientRegistry.removeSink(sink->olinkObjectName());
 }
 
 TEST_CASE("setProperty")
@@ -74,36 +74,37 @@ TEST_CASE("setProperty")
 
     // setup client
     ClientRegistry clientRegistry;
-    ClientNode client(clientRegistry);
-    client.onLog(log.logFunc());
-    CalcSink sink(clientRegistry);
+    auto client = ClientNode::create(clientRegistry);
+    client->onLog(log.logFunc());
+    auto sink = std::make_shared<CalcSink>(clientRegistry);
+    clientRegistry.addSink(sink);
 
     WriteMessageFunc sinkWriteFunc = [&remote](std::string msg) {
         remote->handleMessage(msg);
     };
-    client.onWrite(sinkWriteFunc);
+    client->onWrite(sinkWriteFunc);
 
     WriteMessageFunc sourceWriteFunc = [&client](std::string msg) {
-        client.handleMessage(msg);
+        client->handleMessage(msg);
     };
     remote->onWrite(sourceWriteFunc);
 
     // register source object
     registry.addSource(source);
     clientRegistry.addSink(sink);
-    client.linkRemote("demo.Calc");
+    client->linkRemote("demo.Calc");
 
-    REQUIRE( sink.isReady() == true );
+    REQUIRE( sink->isReady() == true );
     SECTION("set property") {
-        REQUIRE( sink.total() == 1);
-        sink.setTotal(2);
-        REQUIRE( sink.total() == 2);
-        sink.setTotal(3);
-        REQUIRE( sink.total() == 3);
+        REQUIRE( sink->total() == 1);
+        sink->setTotal(2);
+        REQUIRE( sink->total() == 2);
+        sink->setTotal(3);
+        REQUIRE( sink->total() == 3);
     }
 
     registry.removeSource(source->olinkObjectName());
-    clientRegistry.removeSink(sink.olinkObjectName());
+    clientRegistry.removeSink(sink->olinkObjectName());
 }
 
 TEST_CASE("signal")
@@ -118,33 +119,34 @@ TEST_CASE("signal")
 
     // setup client
     ClientRegistry clientRegistry;
-    ClientNode client(clientRegistry);
-    client.onLog(log.logFunc());
-    CalcSink sink(clientRegistry);
+    auto client = ClientNode::create(clientRegistry);
+    client->onLog(log.logFunc());
+    auto sink = std::make_shared<CalcSink>(clientRegistry);
+    clientRegistry.addSink(sink);
 
     WriteMessageFunc sinkWriteFunc = [&remote](std::string msg) {
         remote->handleMessage(msg);
     };
-    client.onWrite(sinkWriteFunc);
+    client->onWrite(sinkWriteFunc);
 
     WriteMessageFunc sourceWriteFunc = [&client](std::string msg) {
-        client.handleMessage(msg);
+        client->handleMessage(msg);
     };
     remote->onWrite(sourceWriteFunc);
 
     // register source object
     registry.addSource(source);
     clientRegistry.addSink(sink);
-    client.linkRemote("demo.Calc");
-    REQUIRE( sink.isReady() == true );
+    client->linkRemote("demo.Calc");
+    REQUIRE( sink->isReady() == true );
 
     SECTION("signal") {
-        REQUIRE( sink.events.size() == 0);
+        REQUIRE( sink->events.size() == 0);
         source->notifyShutdown(10);
-        REQUIRE( sink.events.size() == 1);
+        REQUIRE( sink->events.size() == 1);
     }
     registry.removeSource(source->olinkObjectName());
-    clientRegistry.removeSink(sink.olinkObjectName());
+    clientRegistry.removeSink(sink->olinkObjectName());
 }
 
 
@@ -160,17 +162,18 @@ TEST_CASE("invoke")
 
     // setup client
     ClientRegistry clientRegistry;
-    ClientNode client(clientRegistry);
-    client.onLog(log.logFunc());
-    CalcSink sink(clientRegistry);
+    auto client = ClientNode::create(clientRegistry);
+    client->onLog(log.logFunc());
+    auto sink = std::make_shared<CalcSink>(clientRegistry);
+    clientRegistry.addSink(sink);
 
     WriteMessageFunc clientWriteFunc = [&remote](std::string msg) {
         remote->handleMessage(msg);
     };
-    client.onWrite(clientWriteFunc);
+    client->onWrite(clientWriteFunc);
 
     WriteMessageFunc serviceWriteFunc = [&client](std::string msg) {
-        client.handleMessage(msg);
+        client->handleMessage(msg);
     };
     remote->onWrite(serviceWriteFunc);
 
@@ -178,14 +181,14 @@ TEST_CASE("invoke")
     // register source object
     registry.addSource(source);
     clientRegistry.addSink(sink);
-    client.linkRemote("demo.Calc");
-    REQUIRE( sink.isReady() == true );
+    client->linkRemote("demo.Calc");
+    REQUIRE( sink->isReady() == true );
 
     SECTION("invoke") {
-        REQUIRE( sink.total() == 1);
-        sink.add(5);
-        REQUIRE( sink.total() == 6);
+        REQUIRE( sink->total() == 1);
+        sink->add(5);
+        REQUIRE( sink->total() == 6);
     }
     registry.removeSource(source->olinkObjectName());
-    clientRegistry.removeSink(sink.olinkObjectName());
+    clientRegistry.removeSink(sink->olinkObjectName());
 }


### PR DESCRIPTION
Changes in Registry
- Registry stores weak_pts for nodes and sinks
- registry uses IClientNode instead of a node
- collection of entries in registry is now guarded with mutex
Alignement of a node
- node inherits from shared_from_this, as a remote node - it adds and removes itself from registry depending on a link, unlink requests - this means that the node is stored for a sink linked through this node.  
- client node adds thread safety for handling invoke method requests
- link/unlink for all methods were removed - the registry doesn't store nodes until they are linked, therefore there is no way of getting the information about objects. Unlink for all couldn't be used in dtor
also created an issue for informing a sink that link is ready to use through the node, but passing the node with raw pointer, same in remote node https://github.com/apigear-io/objectlink-core-cpp/issues/26