### PR TITLE
registry-keeps-nodes-with-unique-id

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,29 +12,32 @@ if(NOT nlohmann_json_FOUND)
 endif()
 
 set(OLINK_SOURCES
-    olink/core/types.cpp
     olink/core/basenode.cpp
     olink/core/protocol.cpp
+    olink/core/types.cpp
     olink/consolelogger.cpp
     olink/clientnode.cpp
-    olink/remotenode.cpp
     olink/clientregistry.cpp
-    olink/remoteregistry.cpp)
+    olink/remotenode.cpp
+    olink/remoteregistry.cpp 
+    )
 
 SET(OLINK_HEADERS
-    olink/core/types.h
     olink/core/basenode.h
-    olink/core/protocol.h
-    olink/consolelogger.h
-    olink/clientnode.h
-    olink/remotenode.h
-    olink/clientregistry.h
-    olink/iobjectsink.h
     olink/core/olink_common.h
+    olink/core/protocol.h
+    olink/core/types.h
+    olink/core/uniqueidobjectstorage.h
+    olink/clientnode.h
+    olink/clientregistry.h
+    olink/consolelogger.h
     olink/iclientnode.h
+    olink/iobjectsink.h
+    olink/iobjectsource.h
     olink/iremotenode.h
+    olink/remotenode.h
     olink/remoteregistry.h
-    olink/iobjectsource.h)
+    )
 
 
 add_library (olink_core STATIC ${OLINK_SOURCES} ${OLINK_HEADERS})

--- a/src/olink/clientnode.cpp
+++ b/src/olink/clientnode.cpp
@@ -10,11 +10,17 @@ ClientNode::ClientNode(ClientRegistry& registry)
     : BaseNode()
     , m_nextRequestId(0)
     , m_registry(registry)
-{}
+{
+}
+
+void ClientNode::setNodeId(unsigned long id) {
+    m_nodeId = id;
+}
 
 std::shared_ptr<ClientNode> ClientNode::create(ClientRegistry& registry)
 {
     auto node = std::shared_ptr<ClientNode>(new ClientNode(registry));
+    node->setNodeId(registry.registerNode(node));
     return node;
 }
 
@@ -23,7 +29,7 @@ void ClientNode::linkRemote(const std::string& objectId)
     emitLog(LogLevel::Info, "ClientNode.linkRemote: " + objectId);
     emitWrite(Protocol::linkMessage(objectId));
     m_registry.unsetNode(objectId);
-    m_registry.setNode(shared_from_this(), objectId);
+    m_registry.setNode(m_nodeId, objectId);
 }
 
 void ClientNode::unlinkRemote(const std::string& objectId)
@@ -58,6 +64,21 @@ void ClientNode::setRemoteProperty(const std::string& propertyId, const nlohmann
 ClientRegistry& ClientNode::registry()
 {
     return m_registry;
+}
+
+ClientNode::~ClientNode()
+{
+    auto ids = m_registry.getObjectIds(m_nodeId);
+    for (const auto& id : ids)
+    {
+        unlinkRemote(id);
+    }
+    m_registry.unregisterNode(m_nodeId);
+}
+
+unsigned long ClientNode::getNodeId() const
+{
+    return m_nodeId;
 }
 
 void ClientNode::handleInit(const std::string& objectId, const nlohmann::json& props)

--- a/src/olink/clientnode.h
+++ b/src/olink/clientnode.h
@@ -22,24 +22,33 @@ class IObjectSink;
  * The network implementation should deliver a write function for the node  to allow sending messages
  * see BaseNode::emitWrite and BaseNode::onWrite.
  * A sink that receives a handler call is chosen based on registry entries and objectId retrieved from incoming message.
- * To use objectSink with this client, client needs to be registered in client registry for an object
- * see ClientRegistry::setNode function.
+ * Client node registers itself in registry on creation and removes on destruction, node should not be registered/unregistered manually.
+ * Use linkRemote function to link your sink object with a source and use this node for communication. It already takes care of handling 
+ * setting and unsetting(for unlink) the node for the object in registry. Set and unset in registry should not be done manually.
  */
 class OLINK_EXPORT ClientNode : public BaseNode, public IClientNode, public std::enable_shared_from_this<ClientNode>
 {
 protected:
-    ClientNode(ClientRegistry& registry);
     /**
-    * protected constructor. Use createClientNode to make an instance of ClientNode.
+    * Protected constructor. Use create function to make an instance of ClientNode.
     * @param registry. A global registry for client nodes and object sinks
     */
+    ClientNode(ClientRegistry& registry);
 
+    /*
+    * Protected method to allow assigning the node id from a factory method.
+    * @param id. An id obtained on registration in registry.
+    */
+    void setNodeId(unsigned long id);
 public:
     /**
     * Factory method to create a remote node.
     * @return new ClientNode.
     */
     static std::shared_ptr<ClientNode> create(ClientRegistry& registry);
+
+    /* dtor */
+    ~ClientNode() override;
 
     /** IClientNode::linkRemote implementation. */
     void linkRemote(const std::string& objectId) override;
@@ -52,6 +61,12 @@ public:
 
      /* The registry in which client is registered*/
     ClientRegistry& registry();
+
+    /* 
+    * The id that registry assigned to a node. 
+    * This id is used to connect the node with sink object in registry.
+    */
+    unsigned long getNodeId() const;
 
 protected:
     /** IProtocolListener::handleInit implementation */
@@ -73,6 +88,8 @@ protected:
 private:
     /* The registry in which client is registered and which provides sinks connected with this node*/
     ClientRegistry& m_registry;
+    /* Id of this node in registry.*/
+    unsigned long m_nodeId;
 
     /* Value of last request id.*/
     std::atomic<int> m_nextRequestId;
@@ -80,7 +97,5 @@ private:
     std::map<int,InvokeReplyFunc> m_invokesPending;
     std::mutex m_pendingInvokesMutex;
 };
-
-
 
 } } // ApiGear::ObjectLink

--- a/src/olink/clientregistry.cpp
+++ b/src/olink/clientregistry.cpp
@@ -6,13 +6,12 @@
 namespace ApiGear {
 namespace ObjectLink {
 
-void ClientRegistry::setNode(std::weak_ptr<IClientNode> node, const std::string& objectId)
+void ClientRegistry::setNode(unsigned long id, const std::string& objectId)
 {
 
-    auto lockedNode = node.lock();
+    auto lockedNode = m_clientNodesById.get(id).lock();
     if (!lockedNode){
         emitLog(LogLevel::Warning, "Trying to add node, but it is already gone. Node NOT added.");
-        return;
     }
 
     emitLog(LogLevel::Info, "ClientRegistry.setNode: " + objectId);
@@ -21,11 +20,11 @@ void ClientRegistry::setNode(std::weak_ptr<IClientNode> node, const std::string&
     auto entryForObject = m_entries.find(objectId);
     if (entryForObject == m_entries.end()){
         auto newEntry = SinkToClientEntry();
-        newEntry.node = lockedNode;
         m_entries[objectId] = newEntry;
-    } else if (entryForObject->second.node.lock() == nullptr){
-        entryForObject->second.node = node;
-    } else if (entryForObject->second.node.lock() != lockedNode){
+        newEntry.nodeId = id;
+    } else if (entryForObject->second.nodeId == m_clientNodesById.getInvalidId()){
+        entryForObject->second.nodeId = id;
+    } else if (entryForObject->second.nodeId != id){
         lock.unlock();
         emitLog(LogLevel::Warning, "Trying to set a client node for " + objectId + " but other node is already set. Node was NOT changed.");
     } 
@@ -37,7 +36,7 @@ void ClientRegistry::unsetNode(const std::string& objectId)
     std::unique_lock<std::mutex> lock(m_entriesMutex);
     auto foundEntry = m_entries.find(objectId);
     if (foundEntry != m_entries.end()){
-        foundEntry->second.node.reset();
+        foundEntry->second.nodeId = m_clientNodesById.getInvalidId();
     }
 }
 
@@ -53,6 +52,7 @@ void ClientRegistry::addSink(std::weak_ptr<IObjectSink> sink)
     emitLog(LogLevel::Info, "ClientRegistry.addSink: " + objectId);
     auto newEntry = SinkToClientEntry();
     newEntry.sink = lockedSink;
+    newEntry.nodeId = m_clientNodesById.getInvalidId();
 
     std::unique_lock<std::mutex> lock(m_entriesMutex);
     auto entryForObject = m_entries.find(objectId);
@@ -71,8 +71,11 @@ void ClientRegistry::removeSink(const std::string& objectId)
     emitLog(LogLevel::Info, "ClientRegistry.removeSink: " + objectId);
     std::unique_lock<std::mutex> lock(m_entriesMutex);
     auto entry = m_entries.find(objectId);
-    if (entry != m_entries.end()) {
+    if (entry != m_entries.end()) 
+    {
+        auto nodeId = entry->second.nodeId;
         m_entries.erase(entry);
+        lock.unlock();
     }
 }
 
@@ -84,13 +87,13 @@ std::weak_ptr<IObjectSink> ClientRegistry::getSink(const std::string& objectId)
     return entryForObject != m_entries.end() ? entryForObject->second.sink  : std::weak_ptr<IObjectSink>();
 }
 
-std::vector<std::string> ClientRegistry::getObjectIds(std::weak_ptr<IClientNode> node)
+std::vector<std::string> ClientRegistry::getObjectIds(unsigned long nodeId)
 {
     std::vector<std::string> sinks;
     sinks.reserve(m_entries.size());
     std::unique_lock<std::mutex> lock(m_entriesMutex);
     for (auto& entry : m_entries) {
-        if (entry.second.node.lock() == node.lock()) {
+        if (entry.second.nodeId == nodeId) {
             sinks.push_back(entry.first);
         }
     }
@@ -102,7 +105,31 @@ std::weak_ptr<IClientNode> ClientRegistry::getNode(const std::string& objectId)
     emitLog(LogLevel::Info, "ClientRegistry.getNode: " + objectId);
     std::unique_lock<std::mutex> lock(m_entriesMutex);
     auto entry = m_entries.find(objectId);
-    return entry != m_entries.end() ? entry->second.node : std::weak_ptr<IClientNode>();
+    return entry != m_entries.end() ? m_clientNodesById.get(entry->second.nodeId) : std::weak_ptr<IClientNode>();
+}
+
+unsigned long ClientRegistry::registerNode(std::weak_ptr<IClientNode> node)
+{
+    auto lockedNode = node.lock();
+    if (!lockedNode){
+        emitLog(LogLevel::Warning, "Trying to add node, but it is already gone. Node NOT added.");
+    }
+    return m_clientNodesById.add(lockedNode);
+}
+
+void ClientRegistry::unregisterNode(unsigned long id)
+{
+    if (id != m_clientNodesById.getInvalidId())
+    {
+        std::unique_lock<std::mutex> lock(m_entriesMutex);
+        for (auto& entry : m_entries) {
+            if (entry.second.nodeId == id) {
+                entry.second.nodeId = m_clientNodesById.getInvalidId();
+            }
+        }
+        lock.unlock();
+        m_clientNodesById.remove(id);
+    }
 }
 
 }} //namespace ApiGear::ObjectLink

--- a/src/olink/core/uniqueidobjectstorage.h
+++ b/src/olink/core/uniqueidobjectstorage.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <memory>
+#include <algorithm>
+#include <unordered_map>
+#include <mutex>
+#include <functional>
+
+
+/*
+* Helper class that stores weak_ptr of ObjectType and assigns it unique Id.
+* The class can be used in multi threaded app.
+*/
+template<typename ObjectType>
+class UniqueIdObjectStorage {
+public:
+    /**ctor
+    * @param maxCount Maximum number of objects hold by this storage. By default it is highest unsigned long value.
+    */
+    UniqueIdObjectStorage(unsigned long maxCount = 0xFFFFFFFFu)
+        : m_counter(0),
+        m_maxCount(maxCount)
+    {
+        auto getUniqueAfterOverflow = [this]() -> unsigned long {
+            auto currentId = m_counter;
+            std::unique_lock<std::mutex> lock(m_counterMutex);
+            while (m_objects.find(currentId) != m_objects.end()){
+                currentId += 1;
+                if (m_objects.size() == m_maxCount) return invalidId;
+                if (currentId == m_maxCount){
+                    currentId = 0;
+                }
+            }
+            m_counter = currentId + 1;
+            if (m_counter == m_maxCount){
+                m_counter = 0;
+            }
+            return currentId;
+        };
+
+        getUniqueId = [this, getUniqueAfterOverflow]() -> unsigned long {
+            std::unique_lock<std::mutex> lock(m_counterMutex);
+            unsigned long current_id = m_counter;
+            m_counter += 1;
+            if (m_counter == m_maxCount){
+                m_counter = 0;
+                getUniqueId = getUniqueAfterOverflow;
+            }
+            return current_id;
+        };
+    }
+    
+    /*
+    * Adds an object to a storage and assigns an id for it.
+    * One object is stored only once, if it already exists in the storage then no new id is generated and old one is used.
+    * @param object. An object that will be added to a storage.
+    * @return A unique id for added object. If adding failed the invalid id is returned.
+    */
+    unsigned long add(std::weak_ptr<ObjectType> object)
+    {
+        auto lockedObject = object.lock();
+        if (!lockedObject) return invalidId;
+        if (m_objects.size() == m_maxCount) return invalidId;
+
+        std::unique_lock<std::mutex> lock(m_objectsMutex);
+
+        auto alreadyAddedId = std::find_if(m_objects.begin(), m_objects.end(),
+            [lockedObject](auto current)
+            {
+                return !current.second.expired() &&
+                    current.second.lock() == lockedObject;
+            });
+        if (alreadyAddedId != m_objects.end()) return alreadyAddedId->first;
+
+        auto id = getUniqueId();
+        m_objects[id] = object;
+        return id;
+    }
+    
+    /*
+    * Removes item from storage.
+    * @param id The id of object that is to be removed from storage.
+    */
+    void remove(unsigned long id)
+    {
+        if (m_objects.find(id) != m_objects.end())
+        {
+            std::unique_lock<std::mutex> lock(m_objectsMutex);
+            m_objects.erase(id);
+        }
+    }
+    
+    /*
+    * Gives access to stored object given by id.
+    * @param id The id of object that should be obtained.
+    * @return The object found for given id or expired pointer if object is not in the storage.
+    */
+    std::weak_ptr<ObjectType> get(unsigned long id)
+    {
+        if (m_objects.find(id) != m_objects.end())
+        {
+            return m_objects[id];
+        }
+        return std::weak_ptr<ObjectType>();
+    }
+
+    /*
+    * @return An id that is considered as invalid in this storage. It is the maximum value of unsigned long.
+    */
+    unsigned long getInvalidId() const {return invalidId;}
+private:
+    /** invalid id */
+    const unsigned long invalidId = 0xFFFFFFFFu;
+    /*
+    * A function that generates id.
+    * @returns the unique id to be used among m_objects.
+    */
+    std::function<unsigned long(void)> getUniqueId;
+    /* Maximum number of objects hold by this storage. */
+    const unsigned long m_maxCount;
+    
+    /* Object stored with their unique id. */
+    std::unordered_map<unsigned long, std::weak_ptr<ObjectType>> m_objects;
+    /* A mutex to guard operations on stored objects.*/
+    std::mutex m_objectsMutex;
+    
+    /* A counter to help tracking unique id*/
+    unsigned long m_counter;
+    /* A mutex to guard operations on counter.*/
+    std::mutex m_counterMutex;
+};

--- a/src/olink/remotenode.h
+++ b/src/olink/remotenode.h
@@ -41,17 +41,23 @@ class RemoteRegistry;
  * The network implementation should deliver a write function for the node  to allow sending messages
  * see BaseNode::emitWrite and BaseNode::onWrite.
  * A source that receives a handler call is chosen based on registry entries and objectId retrieved from incoming message.
- * To use object source with this remote node, remote node needs to be registered in same remote registry as the  object source.
+ * To use object source with this remote node, object source needs to be registered in same remote registry as this node.
+ * This node registers itself in registry on creation and removes on destruction, node should not be registered/unregistered manually.
  */
 class OLINK_EXPORT RemoteNode: public BaseNode, public IRemoteNode, public std::enable_shared_from_this<RemoteNode>
 {
 protected:
     /**
-    * protected constructor. Use createRemoteNode to make an instance of RemoteNode.
+    * Protected constructor. Use createRemoteNode to make an instance of RemoteNode.
     * @param registry. A global registry for remote nodes and object sources
     */
     RemoteNode(RemoteRegistry& registry);
 
+    /*
+    * Protected method to allow assigning the node id from a factory method.
+    * @param id. An id obtained on registration in registry.
+    */
+    void setNodeId(unsigned long id);
 public:
     /**
     * Factory method to create a remote node.
@@ -59,7 +65,8 @@ public:
     */
     static std::shared_ptr<RemoteNode> createRemoteNode(RemoteRegistry& registry);
 
-    virtual ~RemoteNode() = default;
+    /** dtor */
+    ~RemoteNode() override;
 
     /**
      * Access the remote registry.
@@ -80,7 +87,16 @@ public:
     void notifyPropertyChange(const std::string& propertyId, const nlohmann::json& value) override;
     /** IRemoteNode::notifySignal implementation. */
     void notifySignal(const std::string& signalId, const nlohmann::json& args) override;
+
+    /* 
+    * The id that registry assigned to a node. 
+    * This id is used to connect the node with source object in registry.
+    */
+    unsigned long getNodeId() const;
 private:
+    /* Id of this node in registry.*/
+    unsigned long m_nodeId;
+
     /** A global remote registry to which the node has subscribed.*/
     RemoteRegistry& m_registry;
 };

--- a/src/olink/remoteregistry.h
+++ b/src/olink/remoteregistry.h
@@ -2,6 +2,7 @@
 
 #include "core/basenode.h"
 #include "core/types.h"
+#include "core/uniqueidobjectstorage.h"
 
 #include <chrono>
 #include <memory>
@@ -21,7 +22,7 @@ class IObjectSource;
  * Each object is registered with its id, available with olinkObjectName() call.
  * This id has to be unique in the registry, only first object with same id will be registered.
  * Also the RemoteNode which is an abstraction for connection endpoint may be used for many objects.
- * The registration is made separately for ObjectSource and RemoteNodes. The order of registration is not relevant, but
+ * The registration and adding the node is made separately for ObjectSource and RemoteNodes. The order of registration is not relevant, but
  * they have to provide same objectId to be associated in following manner:
  * for one unique object source, there can be many remote nodes (each node may be also used for other object source).
  * Source object implementation should always be removed from registry before destroying it.
@@ -50,15 +51,15 @@ public:
     * @param objectId Identifier of a source Object.
     * @return Source Object with given objectId, or nullptr if no source found for an objectId.
     */
-    
     std::weak_ptr<IObjectSource> getSource(const std::string& objectId);
+    
     /**
     * Returns Collection of ids of all objects that are using given node.
-    * @param node A node for which objects using it should be found.
+    * @param nodeId An id of a node, for which objects using it are to be found.
     * @return a collection of Ids of all the objects that use given node.
     */
-    
-    std::vector<std::string> getObjectIds(std::weak_ptr<IRemoteNode> node);
+    std::vector<std::string> getObjectIds(unsigned long nodeId);
+
     /**
     * Returns Remote Nodes for given objectId.
     * @param objectId An id of object, for which the nodes should be searched.
@@ -70,18 +71,28 @@ public:
     /**
     * Add a RemoteNode for a Source Object registered with objectId
     * If no source yet added, the node is still going to be added, for the id.
+    * @param nodeId An id of a RemoteNode to be added for an object Id.
     * @param objectId An id of object, for which the node should be added.
-    * @param node A RemoteNode to be added for an object Id.
+    * @return A unique id given to added node. It should be used to get or remove the node.
     */
-    void addNodeForSource(std::weak_ptr<IRemoteNode> node, const std::string& objectId);
+    void addNodeForSource(unsigned long nodeId, const std::string& objectId);
     /**
     * Remove the RemoteNode from registry for objectId.
+    * @param nodeId An id of a RemoteNode that is going to be removed from source with given objectId.
     * @param objectId An id of object, for which the node should be removed.
-    * @param node A RemoteNode that is going to be removed from source with given objectId.
     *   If there is no object with given objectId or given node is not among nodes registered for this objectId no action is taken.
     */
-    void removeNodeFromSource(std::weak_ptr<IRemoteNode> node, const std::string& objectId);
+    void removeNodeFromSource(unsigned long nodeId, const std::string& objectId);
 
+    /**
+    * Use this function to register node and obtain a unique id, with which you can connect it with sink objects.
+    * @return A unique id given to added node.It should be used to get or remove the node.
+    */
+    unsigned long registerNode(std::weak_ptr<IRemoteNode> node);
+    /**
+    * Remove the node from registry, it will be no longer valid to use with any sink object.
+    */
+    void unregisterNode(unsigned long id);
 private:
 
     /**
@@ -89,7 +100,7 @@ private:
      */
     struct OLINK_EXPORT SourceToNodesEntry {
         std::weak_ptr<IObjectSource> source;
-        std::vector< std::weak_ptr<IRemoteNode>> nodes;
+        std::vector<unsigned long> nodes;
     };
     
     /**
@@ -105,9 +116,10 @@ private:
     * but many RemoteNodes can be used with this objectId as source can be linked with many clients.
     */
     std::map<std::string, SourceToNodesEntry> m_entries;
-
+    /* A mutex to guard operations on stored entries.*/
     std::mutex m_entriesMutex;
-    
+    /* Storage for client nodes, keeps them by Id*/
+    UniqueIdObjectStorage<ApiGear::ObjectLink::IRemoteNode> m_remoteNodesById;
 };
 
 }} //ApiGear::ObjectLink

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_OLINK_SOURCES
     test_client_registry.cpp
     test_client_node.cpp
     test_remote_registry.cpp
+    test_uniqueidstorage.cpp
     test_remote_node.cpp
     sinkobject.hpp
     sourceobject.hpp

--- a/tests/test_client_registry.cpp
+++ b/tests/test_client_registry.cpp
@@ -29,11 +29,10 @@ TEST_CASE("client registry")
         auto node1 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
 
         std::vector<std::string> empty = { };
-        REQUIRE(clientRegistry.getObjectIds(node1) == empty);
-        
-        clientRegistry.setNode(node1, sink1Id);
+        auto id = node1->getNodeId();
+        clientRegistry.setNode(id, sink1Id);
         std::vector<std::string> expectedId = { sink1Id };
-        REQUIRE(clientRegistry.getObjectIds(node1) == expectedId);
+        REQUIRE(clientRegistry.getObjectIds(id) == expectedId);
         REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
         REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
      }
@@ -42,10 +41,10 @@ TEST_CASE("client registry")
     {
         auto node1 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
 
-        REQUIRE(clientRegistry.getObjectIds(node1).size() == 0);
-        clientRegistry.setNode(node1, sink1Id);
+        auto id = node1->getNodeId();
+        clientRegistry.setNode(id, sink1Id);
         std::vector<std::string> expectedId = { sink1Id };
-        REQUIRE(clientRegistry.getObjectIds(node1) == expectedId);
+        REQUIRE(clientRegistry.getObjectIds(id) == expectedId);
 
         REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
         REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
@@ -57,13 +56,13 @@ TEST_CASE("client registry")
         auto node2 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
         clientRegistry.addSink(sink2);
 
-        REQUIRE(clientRegistry.getObjectIds(node1).size() == 0);
-        clientRegistry.setNode(node1, sink1Id);
-        clientRegistry.setNode(node1, sink2Id);
+        auto nodeId = node1->getNodeId();
+        clientRegistry.setNode(nodeId, sink1Id);
+        clientRegistry.setNode(nodeId, sink2Id);
         std::string notExisitnigSinkId = "notExisitnigSinkId";
-        clientRegistry.setNode(node1, notExisitnigSinkId);
+        clientRegistry.setNode(nodeId, notExisitnigSinkId);
         std::vector<std::string> expectedIds = { notExisitnigSinkId, sink1Id, sink2Id };
-        REQUIRE_THAT(clientRegistry.getObjectIds(node1), Catch::Matchers::UnorderedEquals(expectedIds));
+        REQUIRE_THAT(clientRegistry.getObjectIds(nodeId), Catch::Matchers::UnorderedEquals(expectedIds));
 
         // For all ids we're getting same node
         REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
@@ -79,11 +78,13 @@ TEST_CASE("client registry")
     {
         auto node1 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
         auto node2 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
+        auto nodeId1 = node1->getNodeId();
+        auto nodeId2 = node2->getNodeId();
 
-        clientRegistry.setNode(node1, sink1Id);
+        clientRegistry.setNode(nodeId1, sink1Id);
         REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
 
-        clientRegistry.setNode(node2, sink1Id);
+        clientRegistry.setNode(nodeId2, sink1Id);
         // Still node1 set for id
         REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
         REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
@@ -92,7 +93,7 @@ TEST_CASE("client registry")
         REQUIRE(clientRegistry.getNode(sink1Id).lock() == nullptr);
         REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
 
-        clientRegistry.setNode(node2, sink1Id);
+        clientRegistry.setNode(nodeId2, sink1Id);
         // Now node2 is set
         REQUIRE(clientRegistry.getNode(sink1Id).lock() == node2);
         REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
@@ -105,7 +106,9 @@ TEST_CASE("client registry")
         ALLOW_CALL(*differentSinkForId1, olinkObjectName()).RETURN(sink1Id);
 
         auto node1 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
-        clientRegistry.setNode(node1, sink1Id);
+        auto nodeId1 = node1->getNodeId();
+
+        clientRegistry.setNode(nodeId1, sink1Id);
 
         REQUIRE(clientRegistry.getSink(sink1Id).lock() == sink1);
         REQUIRE(clientRegistry.getNode(sink1Id).lock() == node1);
@@ -129,8 +132,8 @@ TEST_CASE("client registry")
     SECTION("Add node first, then the sink")
     {
         auto node1 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
-
-        clientRegistry.setNode(node1, sink2Id);
+        auto nodeId1 = node1->getNodeId();
+        clientRegistry.setNode(nodeId1, sink2Id);
         clientRegistry.addSink(sink2);
 
         REQUIRE(clientRegistry.getSink(sink2Id).lock() == sink2);

--- a/tests/test_remote_node.cpp
+++ b/tests/test_remote_node.cpp
@@ -115,7 +115,7 @@ TEST_CASE("Remote Node")
     }
 
 
-    SECTION("if not on unlink, node has to be removed manually from registry")
+    SECTION("if not on unlink, but node dies anyway, node removes itself from registry")
     {
         registry.addSource(source1);
         REQUIRE_CALL(*source1, olinkCollectProperties()).RETURN(exampleInitProperties);
@@ -125,9 +125,8 @@ TEST_CASE("Remote Node")
         REQUIRE(registry.getNodes(source1Id).size() == 1);
 
         testedNode.reset();
-        // Node is still in registry, but it is not available. 
-        REQUIRE(registry.getNodes(source1Id).size() == 1);
-        REQUIRE(registry.getNodes(source1Id)[0].lock() == nullptr);
+
+        REQUIRE(registry.getNodes(source1Id).size() == 0);
     }
 
     SECTION("handling request property change")

--- a/tests/test_remote_registry.cpp
+++ b/tests/test_remote_registry.cpp
@@ -23,13 +23,14 @@ TEST_CASE("server registry simple tests without threads")
     SECTION("Add object and a node for it") {
 
         auto node1 = ApiGear::ObjectLink::RemoteNode::createRemoteNode(registry);
+        auto nodeId1 = node1->getNodeId();
 
         std::vector<std::string> empty = { };
-        REQUIRE(registry.getObjectIds(node1) == empty);
+        REQUIRE(registry.getObjectIds(nodeId1) == empty);
 
-        registry.addNodeForSource(node1, source1Id);
+        registry.addNodeForSource(nodeId1, source1Id);
         std::vector<std::string> expectedId = { source1Id };
-        REQUIRE(registry.getObjectIds(node1) == expectedId);
+        REQUIRE(registry.getObjectIds(nodeId1) == expectedId);
         REQUIRE(registry.getSource(source1Id).lock() == source1);
         REQUIRE(registry.getNodes(source1Id)[0].lock() == node1);
     }
@@ -38,15 +39,16 @@ TEST_CASE("server registry simple tests without threads")
     {
         auto node1 = ApiGear::ObjectLink::RemoteNode::createRemoteNode(registry);
         auto node2 = ApiGear::ObjectLink::RemoteNode::createRemoteNode(registry);
+        auto nodeId1 = node1->getNodeId();
         registry.addSource(source2);
 
-        REQUIRE(registry.getObjectIds(node1).size() == 0);
-        registry.addNodeForSource(node1, source1Id);
-        registry.addNodeForSource(node1, source2Id);
+        REQUIRE(registry.getObjectIds(nodeId1).size() == 0);
+        registry.addNodeForSource(nodeId1, source1Id);
+        registry.addNodeForSource(nodeId1, source2Id);
         std::string notExisitnigSinkId = "notExisitnigSinkId";
-        registry.addNodeForSource(node1, notExisitnigSinkId);
+        registry.addNodeForSource(nodeId1, notExisitnigSinkId);
         std::vector<std::string> expectedIds = { source1Id, source2Id }; 
-        REQUIRE_THAT(registry.getObjectIds(node1), Catch::Matchers::UnorderedEquals(expectedIds));
+        REQUIRE_THAT(registry.getObjectIds(nodeId1), Catch::Matchers::UnorderedEquals(expectedIds));
 
         // For all ids for which source was added we're getting same node.
         // For one for which there is no source, node wasn't added.
@@ -63,26 +65,28 @@ TEST_CASE("server registry simple tests without threads")
     {
         auto node1 = ApiGear::ObjectLink::RemoteNode::createRemoteNode(registry);
         auto node2 = ApiGear::ObjectLink::RemoteNode::createRemoteNode(registry);
+        auto nodeId1 = node1->getNodeId();
+        auto nodeId2 = node2->getNodeId();
 
-        registry.addNodeForSource(node1, source1Id);
+        registry.addNodeForSource(nodeId1, source1Id);
         auto nodes = registry.getNodes(source1Id);
         REQUIRE(nodes.size() == 1);
         REQUIRE(nodes[0].lock() == node1);
 
-        registry.addNodeForSource(node2, source1Id);
+        registry.addNodeForSource(nodeId2, source1Id);
         nodes = registry.getNodes(source1Id);
         REQUIRE(nodes.size() == 2);
         REQUIRE(nodes[0].lock() == node1);
         REQUIRE(nodes[1].lock() == node2);
 
-        registry.addNodeForSource(node2, source1Id);
+        registry.addNodeForSource(nodeId2, source1Id);
         nodes = registry.getNodes(source1Id);
         nodes = registry.getNodes(source1Id);
         REQUIRE(nodes.size() == 2);
         REQUIRE(nodes[0].lock() == node1);
         REQUIRE(nodes[1].lock() == node2);
 
-        registry.removeNodeFromSource(node1, source1Id);
+        registry.removeNodeFromSource(nodeId1, source1Id);
         nodes = registry.getNodes(source1Id);
         REQUIRE(nodes.size() == 1);
         REQUIRE(nodes[0].lock() == node2);
@@ -96,7 +100,9 @@ TEST_CASE("server registry simple tests without threads")
 
         auto node1 = ApiGear::ObjectLink::RemoteNode::createRemoteNode(registry);
         auto node2 = ApiGear::ObjectLink::RemoteNode::createRemoteNode(registry);
-        registry.addNodeForSource(node1, source1Id);
+        auto nodeId1 = node1->getNodeId();
+
+        registry.addNodeForSource(nodeId1, source1Id);
 
         REQUIRE(registry.getSource(source1Id).lock() == source1);
         REQUIRE(registry.getNodes(source1Id)[0].lock() == node1);
@@ -120,8 +126,8 @@ TEST_CASE("server registry simple tests without threads")
     SECTION("Add node first, then the source")
     {
         auto node1 = ApiGear::ObjectLink::RemoteNode::createRemoteNode(registry);
-
-        registry.addNodeForSource(node1, source2Id);
+        auto nodeId1 = node1->getNodeId();
+        registry.addNodeForSource(nodeId1, source2Id);
         registry.addSource(source2);
 
         REQUIRE(registry.getSource(source2Id).lock() == source2);

--- a/tests/test_uniqueidstorage.cpp
+++ b/tests/test_uniqueidstorage.cpp
@@ -1,0 +1,125 @@
+#include <catch2/catch.hpp>
+
+#include "olink/core/uniqueidobjectstorage.h"
+#include <memory>
+
+#include <string>
+#include <future>
+
+
+class MyTestObject
+{
+};
+template class UniqueIdObjectStorage<MyTestObject>;
+
+TEST_CASE("storage")
+{
+    auto obj1 = std::make_shared<MyTestObject>();
+    auto obj2 = std::make_shared<MyTestObject>();
+    auto obj3 = std::make_shared<MyTestObject>();
+    auto obj4 = std::make_shared<MyTestObject>();
+    auto obj5 = std::make_shared<MyTestObject>();
+    auto obj6 = std::make_shared<MyTestObject>();
+    auto obj7 = std::make_shared<MyTestObject>();
+
+    unsigned long maxStorageCount = 5;
+
+    UniqueIdObjectStorage<MyTestObject> storage(maxStorageCount);
+
+    SECTION("each added object gets unique id")
+    {
+        auto id1 = storage.add(obj1);
+        auto id2 = storage.add(obj2);
+        auto id3 = storage.add(obj3);
+        REQUIRE(id1 != id2);
+        REQUIRE(id2 != id3);
+        REQUIRE(id3 != id1);
+        REQUIRE(storage.get(id1).lock() == obj1);
+        REQUIRE(storage.get(id2).lock() == obj2);
+        REQUIRE(storage.get(id3).lock() == obj3);
+    }
+
+    SECTION("one object is added only once, next adding return same id")
+    {
+        auto id1 = storage.add(obj1);
+        REQUIRE(storage.add(obj1) == id1);
+        REQUIRE(storage.get(id1).lock() == obj1);
+    }
+
+    SECTION("same object added after removal may get new id")
+    {
+        auto id1 = storage.add(obj1);
+        storage.remove(id1);
+        REQUIRE(storage.get(id1).expired() == true);
+        auto id2 = storage.add(obj1);
+        REQUIRE(id1 != id2);
+        REQUIRE(storage.get(id2).lock() == obj1);
+    }
+
+    SECTION("adding object fails - storage full")
+    {
+        auto id1 = storage.add(obj1);
+        auto id2 = storage.add(obj2);
+        auto id3 = storage.add(obj3);
+        auto id4 = storage.add(obj4);
+        auto id5 = storage.add(obj5);
+        auto id6 = storage.add(obj6);
+        auto id7 = storage.add(obj7);
+        REQUIRE(storage.get(id5).lock() == obj5);
+        REQUIRE(storage.get(id6).expired() == true);
+        REQUIRE(storage.get(id7).expired() == true);
+        REQUIRE(id6 == storage.getInvalidId());
+        REQUIRE(id7 == storage.getInvalidId());
+    }
+
+    SECTION("successful adding object after overflow")
+    {
+        auto id1 = storage.add(obj1);
+        auto id2 = storage.add(obj2);
+        auto id3 = storage.add(obj3);
+        auto id4 = storage.add(obj4);
+        auto id5 = storage.add(obj5);
+        storage.remove(id2);
+        storage.remove(id4);
+        auto id6 = storage.add(obj6);
+        auto id7 = storage.add(obj7);
+        REQUIRE(storage.get(id6).lock() == obj6);
+        REQUIRE(storage.get(id7).lock() == obj7);
+        storage.remove(id1);
+        id4 = storage.add(obj4);
+        REQUIRE(storage.get(id4).lock() == obj4);
+    }
+
+    SECTION("unsuccessful adding object after overflow - again overflow")
+    {
+        auto id1 = storage.add(obj1);
+        auto id2 = storage.add(obj2);
+        auto id3 = storage.add(obj3);
+        auto id4 = storage.add(obj4);
+        auto id5 = storage.add(obj5);
+        storage.remove(id2);
+        storage.remove(id4);
+        auto id6 = storage.add(obj6);
+        auto id7 = storage.add(obj7);
+        REQUIRE(storage.get(id6).lock() == obj6);
+        REQUIRE(storage.get(id7).lock() == obj7);
+        id4 = storage.add(obj4);
+        REQUIRE(id4 == storage.getInvalidId());
+        REQUIRE(storage.get(id4).expired() == true);
+    }
+
+    SECTION("Multithreaded adding and remove")
+    {
+        auto id1 = storage.add(obj1);
+        auto future1 = std::async(std::launch::async, [obj2, &storage](){return storage.add(obj2); });
+        auto future2 = std::async(std::launch::async, [obj3, &storage](){return storage.add(obj3); });
+        auto future3 = std::async(std::launch::async, [id1, &storage](){storage.remove(id1); });
+        auto future4 = std::async(std::launch::async, [obj4, &storage](){return storage.add(obj4); });
+        auto future5 = std::async(std::launch::async, [obj5, &storage](){return storage.add(obj5); });
+        REQUIRE(storage.get(future1.get()).lock() == obj2);
+        REQUIRE(storage.get(future2.get()).lock() == obj3);
+        REQUIRE(storage.get(future4.get()).lock() == obj4);
+        REQUIRE(storage.get(future5.get()).lock() == obj5);
+        REQUIRE(storage.get(id1).expired() == true);
+    }
+}


### PR DESCRIPTION
Nodes in registries are now kept with unique id.
User uses this id to add, remove or get the node from registry.
The id is given on node creation node adds itself to registry, and node is removed from registry, freeing the id on its destruction.
However for now the registry allows other actors to use register/unregister node it shall not be used by other actors than the node.