### PR TITLE
feat: add initial performacne test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(objectlink-core-cpp LANGUAGES CXX)
 
 include(CTest)
 option(BUILD_EXAMPLES "Build examples" FALSE)
+option(PERFORMANCE_TESTS "Build performance tests" FALSE)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -14,6 +15,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_subdirectory (src)
 add_subdirectory (tests)
 
+if(PERFORMANCE_TESTS)
+    add_subdirectory (performance)
+endif()
 
 if(BUILD_EXAMPLES)
     add_subdirectory (examples/app)

--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.1)
+project(performace_tests)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+
+if(NOT TARGET check)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+endif()
+
+add_subdirectory(testApi/modules/api_module/api)
+add_subdirectory(testApi/apigear)
+
+
+add_executable(test_client_side test_client_node.cpp)
+add_executable(test_remote_side test_remote_node.cpp)
+
+
+target_link_libraries(test_client_side olink_core api::api-olink )
+target_link_libraries(test_remote_side olink_core api::api-olink api::api-implementation)

--- a/performance/README.md
+++ b/performance/README.md
@@ -1,0 +1,13 @@
+tests are designed to find bottle necks of using the objectlink protocol handling infrastructure: client node, remote node and the registries
+they are to be started under performance profiler (e.g. Visual Studio Performance Profiler)
+tests are not using any test framework - to exclude 3rd party calls
+tests use generated implementation of apigear/performance_interface.module for test sinks and source, no other apigear functionality is necessary as tests don't use network layer. The objects are using fake object name to allow testing many objects in registry with one generated api.
+Load should be performed in the network layer implementation - so not for this repository.
+
+To allow building test set the PERFORMANCE_TESTS option in TopLEvel CMakeLists to TRUE
+
+In case the sinks and sources need to be regenerated please do following:
+1. Make sure the API file is in shape you want `objectlink-core-cpp\performance\apigear\performance_interface.module.yaml`
+2. Make sure the solution file `objectlink-core-cpp\performance\apigear\performance.solution.yaml` generates the olink and stubs feature and it uses template-cpp14 
+3. Not all folders are necessary - the testApi/apigear/ should only contain the utilities - the network layer is not necessary, also the CMakeLists.txt and ApigearConfig.cmake.in were changed to remove those directories.
+4. The Cmake for  oink feature needs to be changed `objectlink-core-cpp\performance\testApi\modules\api_module\api\generated\olink\CMakeLists.txt` it should now link to `olink-core` and `apigear-utilities`

--- a/performance/apigear/performance.solution.yaml
+++ b/performance/apigear/performance.solution.yaml
@@ -1,0 +1,12 @@
+schema: "apigear.solution/1.0"
+name: performance
+version: "0.1"
+
+layers:
+  - name: test
+    inputs:
+      - performance_interface.module.yaml
+    output: ../testApi
+    template: apigear-io/template-cpp14
+    force: true
+    features: ["olink", "stubs"]

--- a/performance/apigear/performance_interface.module.yaml
+++ b/performance/apigear/performance_interface.module.yaml
@@ -1,0 +1,45 @@
+schema: apigear.module/1.0
+name: api
+version: "1.0"
+
+# test properties with simple types
+# test properties with arrays of simple types
+# test functions with simple types
+# test functions with arrays of simple types
+# test signals with simple types
+# test signals with arrays of simple types
+# test return with simple types
+# test return with arrays of simple types
+
+interfaces:
+  - name: TestApi
+    properties:
+      - { name: propInt, type: int }
+      - { name: propFloat, type: float }
+      - { name: propString, type: string }
+    operations:
+      - name: funcInt
+        params:
+          - { name: paramInt, type: int }
+        return:
+          type: int
+      - name: funcFloat
+        params:
+          - { name: paramFloat, type: float }
+        return:
+          type: float
+      - name: funcString
+        params:
+          - { name: paramString, type: string }
+        return:
+          type: string
+    signals:
+      - name: sigInt
+        params:
+          - { name: paramInt, type: int }
+      - name: sigFloat
+        params:
+          - { name: paramFloat, type: float }
+      - name: sigString
+        params:
+          - { name: paramString, type: string }

--- a/performance/testApi/apigear/ApigearConfig.cmake.in
+++ b/performance/testApi/apigear/ApigearConfig.cmake.in
@@ -1,0 +1,12 @@
+set(APIGEAR_VERSION 1.0)
+@PACKAGE_INIT@
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ApiGearUtilitiesTargets.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ApiGearPocoOlinkTargets.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ApiGearPocoTracerTargets.cmake")
+set_and_check(APIGEAR_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+
+# make sure we have all needed dependencies
+include(CMakeFindDependencyMacro)
+find_dependency(nlohmann_json REQUIRED)
+
+check_required_components(apigear-utilities)

--- a/performance/testApi/apigear/CMakeLists.txt
+++ b/performance/testApi/apigear/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.14)
+project(apigear)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(apigear_COMPONENTS "")
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_BINARY_DIR})
+set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/package)
+set(INCLUDE_INSTALL_DIR include/apigear/ CACHE FILEPATH "")
+set(LIB_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/lib/ CACHE FILEPATH "")
+set(InstallDir ${LIB_INSTALL_DIR}/cmake/apigear)
+
+add_subdirectory(utilities)
+list(APPEND apigear_COMPONENTS "utilities")
+
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(ApigearConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/apigearConfig.cmake
+  INSTALL_DESTINATION ${InstallDir}
+  PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/apigearConfigVersion.cmake
+  VERSION 0.1.0
+  COMPATIBILITY SameMinorVersion )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/apigearConfig.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/apigearConfigVersion.cmake
+        DESTINATION ${InstallDir} )

--- a/performance/testApi/apigear/utilities/CMakeLists.txt
+++ b/performance/testApi/apigear/utilities/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.20)
+project(apigear-utilities)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set (SOURCES
+    logger.cpp
+)
+add_library(apigear-utilities SHARED ${SOURCES})
+add_library(apigear::utilities ALIAS apigear-utilities)
+target_include_directories(apigear-utilities
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../>
+    $<INSTALL_INTERFACE:include>
+)
+
+# install binary files
+install(TARGETS apigear-utilities
+        EXPORT ApiGearUtilitiesTargets
+        RUNTIME DESTINATION bin           COMPONENT Runtime
+        LIBRARY DESTINATION lib           COMPONENT Runtime
+        ARCHIVE DESTINATION lib           COMPONENT Development)
+# install includes
+FILE(GLOB_RECURSE APIGEAR_INCLUDES *.h)
+install(FILES ${APIGEAR_INCLUDES}
+        DESTINATION include/apigear/utilities)
+
+export(EXPORT ApiGearUtilitiesTargets
+  NAMESPACE apigear::
+)
+
+install(EXPORT ApiGearUtilitiesTargets
+  FILE ApiGearUtilitiesTargets.cmake
+  DESTINATION ${InstallDir}
+  NAMESPACE apigear::
+)

--- a/performance/testApi/apigear/utilities/logger.cpp
+++ b/performance/testApi/apigear/utilities/logger.cpp
@@ -1,0 +1,93 @@
+/*
+* MIT License
+*
+* Copyright (c) 2021 ApiGear
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "logger.h"
+#include <iostream>
+
+
+
+namespace ApiGear { namespace Utilities {
+
+static WriteLogFunc logFunc = getConsoleLogFunc(LogLevel::Warning);
+
+void emitLog(LogLevel level, const std::string& msg){
+    if(logFunc) {
+        logFunc(level, msg);
+    }
+}
+
+void setLog(WriteLogFunc func){
+    logFunc = func;
+}
+
+WriteLogFunc getConsoleLogFunc(LogLevel minimumLevel){
+    return [minimumLevel](LogLevel level, const std::string& msg)
+    {
+        auto levelText = "[debug  ] ";
+
+        if (level < minimumLevel){
+            return;
+        }
+
+        switch (level)
+        {
+            case LogLevel::Debug:
+                levelText = "[debug  ] ";
+                std::clog<< levelText << msg << std::endl;
+                break;
+            case LogLevel::Error:
+                levelText = "[error  ] ";
+                std::cerr<< levelText << msg << std::endl;
+                break;
+            case LogLevel::Warning:
+                levelText = "[warning] ";
+                std::cerr<< levelText << msg << std::endl;
+                break;
+            case LogLevel::Info:
+                levelText = "[info   ] ";
+                std::cout<< levelText << msg << std::endl;
+                break;
+            default:
+                break;
+        }
+    };
+}
+
+void logInfo(const std::string& msg){
+    emitLog(LogLevel::Info, msg);
+}
+
+void logDebug(const std::string& msg){
+    emitLog(LogLevel::Debug, msg);
+}
+
+void logWarning(const std::string& msg){
+    emitLog(LogLevel::Warning, msg);
+}
+
+void logError(const std::string& msg){
+    emitLog(LogLevel::Error, msg);
+}
+
+} } // ApiGear::Utilities
+

--- a/performance/testApi/apigear/utilities/logger.h
+++ b/performance/testApi/apigear/utilities/logger.h
@@ -1,0 +1,109 @@
+/*
+* MIT License
+*
+* Copyright (c) 2021 ApiGear
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#pragma once
+
+#include <functional>
+#include <string>
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define APIGEAR_LOGGER __attribute__ ((dllexport))
+#else
+#define APIGEAR_LOGGER __declspec(dllexport)
+#endif
+#else
+#if __GNUC__ >= 4
+#define APIGEAR_LOGGER __attribute__ ((visibility ("default")))
+#else
+#define APIGEAR_LOGGER
+#endif
+#endif
+
+
+namespace ApiGear { namespace Utilities {
+
+/**
+* Logging levels for logs across the application.
+*/
+enum APIGEAR_LOGGER LogLevel {
+    Debug = 0,      // Useful for debugging during development
+    Info = 1,       // Some event happened, usually not important
+    Warning = 2,    // Important to know
+    Error = 3       // Must know - something is wrong
+};
+
+/** A type of function to log*/
+using WriteLogFunc = std::function<void(LogLevel level, const std::string& msg)>;
+
+/* 
+* Set any log function which implements the WriteLogFunc signature
+* 
+* Can be used to disable logging or to write to a file or database.
+*
+* @param func a functions which implements the WriteLogFunc signature
+*/
+void APIGEAR_LOGGER setLog(WriteLogFunc func);
+
+/* 
+* Get the default console log function
+*
+* @param minimumLevel report only log events which are at least as severe
+* @return func returns the default console log function
+*/
+WriteLogFunc APIGEAR_LOGGER getConsoleLogFunc(LogLevel minimumLevel);
+
+/*
+* Use to log
+*
+* @param level specify the LogLevel
+* @param msg content to be logged
+*/
+void APIGEAR_LOGGER emitLog(LogLevel level,const std::string& msg);
+
+/*
+* Use to log on LogLevel::Info
+*/
+void APIGEAR_LOGGER logInfo(const std::string& msg);
+
+/*
+* Use to log on LogLevel::Debug
+*/
+void APIGEAR_LOGGER logDebug(const std::string& msg);
+
+/*
+* Use to log on LogLevel::Warning
+*/
+void APIGEAR_LOGGER logWarning(const std::string& msg);
+
+/*
+* Use to log on LogLevel::Error
+*/
+void APIGEAR_LOGGER logError(const std::string& msg);
+
+} } // ApiGear::Utilities
+
+#define AG_LOG_INFO(str) ApiGear::Utilities::logInfo(str)
+#define AG_LOG_DEBUG(str) ApiGear::Utilities::logDebug(str)
+#define AG_LOG_WARNING(str) ApiGear::Utilities::logWarning(str)
+#define AG_LOG_ERROR(str) ApiGear::Utilities::logError(str)

--- a/performance/testApi/modules/api_module/api/ApiConfig.cmake.in
+++ b/performance/testApi/modules/api_module/api/ApiConfig.cmake.in
@@ -1,0 +1,20 @@
+set(API_VERSION 1.0)
+@PACKAGE_INIT@
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ApiApiTargets.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ApiCoreTargets.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ApiOLinkTargets.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ApiImplementationTargets.cmake")
+set_and_check(API_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+
+# make sure we have all needed dependencies
+include(CMakeFindDependencyMacro)
+find_dependency(Threads REQUIRED)
+find_dependency(apigear COMPONENTS poco-tracer poco-olink REQUIRED)
+
+check_required_components(
+Api-api
+Api-core
+
+Api-olink
+Api-implementation
+)

--- a/performance/testApi/modules/api_module/api/CMakeLists.txt
+++ b/performance/testApi/modules/api_module/api/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.1)
+project(api)
+
+include(CTest)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(INCLUDE_INSTALL_DIR include/api/ CACHE FILEPATH "")
+set(LIB_INSTALL_DIR lib/ CACHE FILEPATH "")
+set(InstallDir ${LIB_INSTALL_DIR}/cmake/api)
+
+add_subdirectory(generated/api)
+add_subdirectory(generated/core)
+add_subdirectory(implementation)
+add_subdirectory(generated/olink)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(ApiConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/apiConfig.cmake
+  INSTALL_DESTINATION ${InstallDir}
+  PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/apiConfigVersion.cmake
+  VERSION 1.0
+  COMPATIBILITY SameMinorVersion )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/apiConfig.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/apiConfigVersion.cmake
+        DESTINATION ${InstallDir} )

--- a/performance/testApi/modules/api_module/api/generated/api/CMakeLists.txt
+++ b/performance/testApi/modules/api_module/api/generated/api/CMakeLists.txt
@@ -1,0 +1,31 @@
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+add_library(api-api INTERFACE)
+add_library(api::api-api ALIAS api-api)
+target_include_directories(api-api
+    INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../../modules>
+    $<INSTALL_INTERFACE:include/api>
+)
+
+# install binary files
+install(TARGETS api-api
+        EXPORT ApiApiTargets
+        RUNTIME DESTINATION bin                 COMPONENT Runtime
+        LIBRARY DESTINATION lib                 COMPONENT Runtime
+        ARCHIVE DESTINATION lib/api   COMPONENT Development)
+# install includes
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include/api/generated FILES_MATCHING PATTERN "*.h")
+
+export(EXPORT ApiApiTargets
+  NAMESPACE api::
+)
+
+install(EXPORT ApiApiTargets
+  FILE ApiApiTargets.cmake
+  DESTINATION ${InstallDir}
+  NAMESPACE api::
+)

--- a/performance/testApi/modules/api_module/api/generated/api/api.h
+++ b/performance/testApi/modules/api_module/api/generated/api/api.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "api/generated/api/datastructs.api.h"
+#include "api/generated/api/testapi.api.h"

--- a/performance/testApi/modules/api_module/api/generated/api/common.h
+++ b/performance/testApi/modules/api_module/api/generated/api/common.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+  #define TEST_API_EXPORT __attribute__ ((dllexport))
+#else
+  #define TEST_API_EXPORT __declspec(dllexport)
+#endif
+#else
+  #if __GNUC__ >= 4
+    #define TEST_API_EXPORT __attribute__ ((visibility ("default")))
+  #else
+    #define TEST_API_EXPORT
+  #endif
+#endif

--- a/performance/testApi/modules/api_module/api/generated/api/datastructs.api.cpp
+++ b/performance/testApi/modules/api_module/api/generated/api/datastructs.api.cpp
@@ -1,0 +1,6 @@
+#include "api/generated/api/datastructs.api.h"
+
+namespace Test {
+namespace Api {
+} // namespace Api
+} // namespace Test

--- a/performance/testApi/modules/api_module/api/generated/api/datastructs.api.h
+++ b/performance/testApi/modules/api_module/api/generated/api/datastructs.api.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cinttypes>
+#include <string>
+#include <list>
+
+#include "api/generated/api/common.h"
+
+namespace Test {
+namespace Api {
+} // namespace Api
+} // namespace Test

--- a/performance/testApi/modules/api_module/api/generated/api/testapi.api.h
+++ b/performance/testApi/modules/api_module/api/generated/api/testapi.api.h
@@ -1,0 +1,326 @@
+#pragma once
+
+#include <future>
+#include "api/generated/api/common.h"
+#include "api/generated/api/datastructs.api.h"
+
+namespace Test {
+namespace Api {
+
+class ITestApiSubscriber;
+class ITestApiPublisher;
+
+/**
+*
+* ITestApi provides an interface for
+ *  - methods defined for your TestApi 
+ *  - property setters and getters for defined properties
+ * The ITestApi also provides an interface to access a publisher ITestApiPublisher, a class used by ITestApiSubscriber clients.
+ * The implementation should notify the publisher ITestApiPublisher about emitted signals or state changed. 
+ * The publisher responsibility is to keep its clients informed about requested changes.
+ * See also ITestApiSubscriber, ITestApiPublisher
+ * and the example implementation TestApi  or the
+ */
+class TEST_API_EXPORT ITestApi
+{
+public:
+    virtual ~ITestApi() = default;
+
+
+    virtual int funcInt(int paramInt) = 0;
+    /**
+    * Asynchronous version of funcInt(int paramInt)
+    * @return Promise of type int which is set once the function has completed
+    */
+    virtual std::future<int> funcIntAsync(int paramInt) = 0;
+
+
+    virtual float funcFloat(float paramFloat) = 0;
+    /**
+    * Asynchronous version of funcFloat(float paramFloat)
+    * @return Promise of type float which is set once the function has completed
+    */
+    virtual std::future<float> funcFloatAsync(float paramFloat) = 0;
+
+
+    virtual std::string funcString(const std::string& paramString) = 0;
+    /**
+    * Asynchronous version of funcString(const std::string& paramString)
+    * @return Promise of type std::string which is set once the function has completed
+    */
+    virtual std::future<std::string> funcStringAsync(const std::string& paramString) = 0;
+
+    /**
+    * Sets the value of the propInt property.
+    */
+    virtual void setPropInt(int propInt) = 0;
+    /**
+    * Gets the value of the propInt property.
+    */
+    virtual int getPropInt() const = 0;
+
+    /**
+    * Sets the value of the propFloat property.
+    */
+    virtual void setPropFloat(float propFloat) = 0;
+    /**
+    * Gets the value of the propFloat property.
+    */
+    virtual float getPropFloat() const = 0;
+
+    /**
+    * Sets the value of the propString property.
+    */
+    virtual void setPropString(const std::string& propString) = 0;
+    /**
+    * Gets the value of the propString property.
+    */
+    virtual const std::string& getPropString() const = 0;
+
+    /**
+    * Access to a publisher, use it to subscribe for TestApi changes and signal emission.
+    * This function name doesn't follow the convention, because it is added to user defined interface,
+    * to avoid potentially name clashes, it has the trailing underscore in the name.
+    * @return The publisher for TestApi.
+    */
+    virtual ITestApiPublisher& _getPublisher() const = 0;
+};
+
+
+/**
+ * The ITestApiSubscriber contains functions to allow informing about signals or property changes of the ITestApi implementation.
+ * The implementation for ITestApi should provide mechanism for subscription of the ITestApiSubscriber clients.
+ * See ITestApiPublisher, which provides facilitation for this purpose.
+ * The implementation for ITestApi should call the ITestApiSubscriber interface functions on either signal emit or property change.
+ * You can use ITestApiSubscriber class to implement clients of the ITestApi or the network adapter - see Olink Server and Client example.
+ */
+class TEST_API_EXPORT ITestApiSubscriber
+{
+public:
+    virtual ~ITestApiSubscriber() = default;
+    /**
+    * Called by the ITestApiPublisher when the TestApi emits sigInt, if subscribed for the sigInt.
+    * @param paramInt 
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onSigInt(int paramInt) = 0;
+    /**
+    * Called by the ITestApiPublisher when the TestApi emits sigFloat, if subscribed for the sigFloat.
+    * @param paramFloat 
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onSigFloat(float paramFloat) = 0;
+    /**
+    * Called by the ITestApiPublisher when the TestApi emits sigString, if subscribed for the sigString.
+    * @param paramString 
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onSigString(const std::string& paramString) = 0;
+    /**
+    * Called by the ITestApiPublisher when propInt value has changed if subscribed for the propInt change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropIntChanged(int propInt) = 0;
+    /**
+    * Called by the ITestApiPublisher when propFloat value has changed if subscribed for the propFloat change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropFloatChanged(float propFloat) = 0;
+    /**
+    * Called by the ITestApiPublisher when propString value has changed if subscribed for the propString change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropStringChanged(const std::string& propString) = 0;
+};
+
+/** Callback for changes of propInt */
+using TestApiPropIntPropertyCb = std::function<void(int propInt)>;
+/** Callback for changes of propFloat */
+using TestApiPropFloatPropertyCb = std::function<void(float propFloat)>;
+/** Callback for changes of propString */
+using TestApiPropStringPropertyCb = std::function<void(const std::string& propString)>;
+/** Callback for sigInt signal triggers */
+using TestApiSigIntSignalCb = std::function<void(int paramInt)> ;
+/** Callback for sigFloat signal triggers */
+using TestApiSigFloatSignalCb = std::function<void(float paramFloat)> ;
+/** Callback for sigString signal triggers */
+using TestApiSigStringSignalCb = std::function<void(const std::string& paramString)> ;
+
+
+/**
+ * The ITestApiPublisher provides an api for clients to subscribe to or unsubscribe from a signal emission 
+ * or a property change.
+ * Implement this interface to keep track of clients of your ITestApi implementation.
+ * The publisher provides two independent methods of subscription
+ *  - subscribing with a IITestApiSubscriber objects - for all of the changes
+ *  - subscribing any object for single type of change property or a signal
+ * The publish functions needs to be called by implementation of the IITestApi on each state changed or signal emitted
+ * to notify all the subscribers about this change.
+ */
+class TEST_API_EXPORT ITestApiPublisher
+{
+public:
+    virtual ~ITestApiPublisher() = default;
+
+    /**
+    * Use this function to subscribe for any change of the TestApi.
+    * Subscriber will be informed of any emitted signal and any property changes.
+    * This is parallel notification system to single subscription. If you will subscribe also for a single change
+    * your subscriber will be informed twice about that change, one for each subscription mechanism.
+    * @param ITestApiSubscriber which is subscribed in this function to any change of the TestApi.
+    */
+    virtual void subscribeToAllChanges(ITestApiSubscriber& subscriber) = 0;
+    /**
+    * Use this function to remove subscription to all of the changes of the TestApi.
+    * Not all subscriptions will be removed, the ones made separately for single signal or property change stay intact.
+    * Make sure to remove them.
+    * @param ITestApiSubscriber which subscription for any change of the TestApi is removed.
+    */
+    virtual void unsubscribeFromAllChanges(ITestApiSubscriber& subscriber) = 0;
+
+    /**
+    * Use this function to subscribe for propInt value changes.
+    * If your subscriber uses subscription with ITestApiSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param TestApiPropIntPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual long subscribeToPropIntChanged(TestApiPropIntPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propInt property changes.
+    * If your subscriber uses subscription with ITestApiSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropIntChanged(long handleId) = 0;
+
+    /**
+    * Use this function to subscribe for propFloat value changes.
+    * If your subscriber uses subscription with ITestApiSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param TestApiPropFloatPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual long subscribeToPropFloatChanged(TestApiPropFloatPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propFloat property changes.
+    * If your subscriber uses subscription with ITestApiSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropFloatChanged(long handleId) = 0;
+
+    /**
+    * Use this function to subscribe for propString value changes.
+    * If your subscriber uses subscription with ITestApiSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param TestApiPropStringPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual long subscribeToPropStringChanged(TestApiPropStringPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propString property changes.
+    * If your subscriber uses subscription with ITestApiSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropStringChanged(long handleId) = 0;
+
+    /**
+    * Use this function to subscribe for sigInt signal changes.
+    * @param TestApiSigIntSignalCb callback that will be executed on each signal emission.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual long subscribeToSigInt(TestApiSigIntSignalCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from sigInt signal changes.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromSigInt(long handleId) = 0;
+
+    /**
+    * Use this function to subscribe for sigFloat signal changes.
+    * @param TestApiSigFloatSignalCb callback that will be executed on each signal emission.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual long subscribeToSigFloat(TestApiSigFloatSignalCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from sigFloat signal changes.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromSigFloat(long handleId) = 0;
+
+    /**
+    * Use this function to subscribe for sigString signal changes.
+    * @param TestApiSigStringSignalCb callback that will be executed on each signal emission.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual long subscribeToSigString(TestApiSigStringSignalCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from sigString signal changes.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromSigString(long handleId) = 0;
+
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the TestApi implementation when property propInt changes.
+    * @param The new value of propInt.
+    */
+    virtual void publishPropIntChanged(int propInt) const = 0;
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the TestApi implementation when property propFloat changes.
+    * @param The new value of propFloat.
+    */
+    virtual void publishPropFloatChanged(float propFloat) const = 0;
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the TestApi implementation when property propString changes.
+    * @param The new value of propString.
+    */
+    virtual void publishPropStringChanged(const std::string& propString) const = 0;
+    /**
+    * Publishes the emitted signal to all subscribed clients.
+    * Needs to be invoked by the TestApi implementation when sigInt is emitted.
+    * @param paramInt 
+    */
+    virtual void publishSigInt(int paramInt) const = 0;
+    /**
+    * Publishes the emitted signal to all subscribed clients.
+    * Needs to be invoked by the TestApi implementation when sigFloat is emitted.
+    * @param paramFloat 
+    */
+    virtual void publishSigFloat(float paramFloat) const = 0;
+    /**
+    * Publishes the emitted signal to all subscribed clients.
+    * Needs to be invoked by the TestApi implementation when sigString is emitted.
+    * @param paramString 
+    */
+    virtual void publishSigString(const std::string& paramString) const = 0;
+};
+
+
+} // namespace Api
+} // namespace Test

--- a/performance/testApi/modules/api_module/api/generated/core/CMakeLists.txt
+++ b/performance/testApi/modules/api_module/api/generated/core/CMakeLists.txt
@@ -1,0 +1,55 @@
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(nlohmann_json QUIET)
+if(NOT nlohmann_json_FOUND)
+  # pull nlohmann json as dependency
+  message(STATUS "nlohmann_json NOT FOUND, fetching the release package")
+  include(FetchContent)
+  set(JSON_Install ON)
+  FetchContent_Declare(json
+  GIT_REPOSITORY https://github.com/nlohmann/json
+  GIT_TAG v3.7.3)
+  FetchContent_MakeAvailable(json)
+endif()
+
+set (SOURCES_CORE_SUPPORT
+    api.json.adapter.cpp
+    testapi.publisher.cpp
+    testapi.threadsafedecorator.cpp
+)
+add_library(api-core SHARED ${SOURCES_CORE_SUPPORT})
+add_library(api::api-core ALIAS api-core)
+target_include_directories(api-core
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../../modules>
+    $<INSTALL_INTERFACE:include/api>
+)
+target_link_libraries(api-core PUBLIC api::api-api nlohmann_json::nlohmann_json)
+# ensure maximum compiler support
+if(NOT MSVC)
+  target_compile_options(api-core PRIVATE -Wall -Wextra -Wpedantic -Werror -fvisibility=hidden)
+else()
+  target_compile_options(api-core PRIVATE /W4 /WX /wd4251)
+endif()
+
+install(TARGETS api-core
+        EXPORT ApiCoreTargets
+        RUNTIME DESTINATION bin                 COMPONENT Runtime
+        LIBRARY DESTINATION lib                 COMPONENT Runtime
+        ARCHIVE DESTINATION lib/api   COMPONENT Development)
+# install includes
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include/api/generated FILES_MATCHING PATTERN "*.h")
+
+export(EXPORT ApiCoreTargets
+  NAMESPACE api::
+)
+
+install(EXPORT ApiCoreTargets
+  FILE ApiCoreTargets.cmake
+  DESTINATION ${InstallDir}
+  NAMESPACE api::
+)

--- a/performance/testApi/modules/api_module/api/generated/core/api.json.adapter.cpp
+++ b/performance/testApi/modules/api_module/api/generated/core/api.json.adapter.cpp
@@ -1,0 +1,6 @@
+#include "api/generated/core/api.json.adapter.h"
+
+namespace Test {
+namespace Api {
+} // namespace Api
+} // namespace Test

--- a/performance/testApi/modules/api_module/api/generated/core/api.json.adapter.h
+++ b/performance/testApi/modules/api_module/api/generated/core/api.json.adapter.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifndef JSON_USE_IMPLICIT_CONVERSIONS
+#define JSON_USE_IMPLICIT_CONVERSIONS 0
+#endif
+#include <nlohmann/json.hpp>
+#include "api/generated/api/datastructs.api.h"
+#include "api/generated/api/common.h"
+
+namespace Test {
+namespace Api {
+} // namespace Api
+} // namespace Test

--- a/performance/testApi/modules/api_module/api/generated/core/api.test.cpp
+++ b/performance/testApi/modules/api_module/api/generated/core/api.test.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"

--- a/performance/testApi/modules/api_module/api/generated/core/testapi.data.h
+++ b/performance/testApi/modules/api_module/api/generated/core/testapi.data.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "api/generated/api/api.h"
+
+
+namespace Test
+{
+namespace Api
+{
+
+/**
+* A helper structure for implementations of TestApi. Stores all the properties.
+*/
+struct TestApiData
+{
+    int m_propInt {0};
+    float m_propFloat {0.0f};
+    std::string m_propString {std::string()};
+};
+
+}
+}

--- a/performance/testApi/modules/api_module/api/generated/core/testapi.publisher.cpp
+++ b/performance/testApi/modules/api_module/api/generated/core/testapi.publisher.cpp
@@ -1,0 +1,243 @@
+
+
+#include "api/generated/core/testapi.publisher.h"
+#include <algorithm>
+
+
+using namespace Test::Api;
+
+void TestApiPublisher::subscribeToAllChanges(ITestApiSubscriber& subscriber)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_allChangesSubscribersMutex);
+    auto found = std::find_if(m_allChangesSubscribers.begin(), m_allChangesSubscribers.end(),
+                        [&subscriber](const auto element){return &(element.get()) == &subscriber;});
+    if (found == m_allChangesSubscribers.end())
+    {
+        m_allChangesSubscribers.push_back(std::reference_wrapper<ITestApiSubscriber>(subscriber));
+    }
+}
+
+void TestApiPublisher::unsubscribeFromAllChanges(ITestApiSubscriber& subscriber)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_allChangesSubscribersMutex);
+    auto found = std::find_if(m_allChangesSubscribers.begin(), m_allChangesSubscribers.end(),
+                        [&subscriber](const auto element){return &(element.get()) == &subscriber;});
+    if (found != m_allChangesSubscribers.end())
+    {
+        m_allChangesSubscribers.erase(found);
+    }
+}
+
+long TestApiPublisher::subscribeToPropIntChanged(TestApiPropIntPropertyCb callback)
+{
+    auto handleId = m_propIntChangedCallbackNextId++;
+    std::unique_lock<std::shared_timed_mutex> lock(m_propIntCallbacksMutex);
+    m_propIntCallbacks[handleId] = callback;
+    return handleId;
+}
+
+void TestApiPublisher::unsubscribeFromPropIntChanged(long handleId)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propIntCallbacksMutex);
+    m_propIntCallbacks.erase(handleId);
+}
+
+void TestApiPublisher::publishPropIntChanged(int propInt) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropIntChanged(propInt);
+    }
+    std::shared_lock<std::shared_timed_mutex> propIntCallbacksLock(m_propIntCallbacksMutex);
+    const auto propIntCallbacks = m_propIntCallbacks;
+    propIntCallbacksLock.unlock();
+    for(const auto& callbackEntry: propIntCallbacks)
+    {
+        if(callbackEntry.second)
+        {
+            callbackEntry.second(propInt);
+        }
+    }
+}
+
+long TestApiPublisher::subscribeToPropFloatChanged(TestApiPropFloatPropertyCb callback)
+{
+    auto handleId = m_propFloatChangedCallbackNextId++;
+    std::unique_lock<std::shared_timed_mutex> lock(m_propFloatCallbacksMutex);
+    m_propFloatCallbacks[handleId] = callback;
+    return handleId;
+}
+
+void TestApiPublisher::unsubscribeFromPropFloatChanged(long handleId)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propFloatCallbacksMutex);
+    m_propFloatCallbacks.erase(handleId);
+}
+
+void TestApiPublisher::publishPropFloatChanged(float propFloat) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropFloatChanged(propFloat);
+    }
+    std::shared_lock<std::shared_timed_mutex> propFloatCallbacksLock(m_propFloatCallbacksMutex);
+    const auto propFloatCallbacks = m_propFloatCallbacks;
+    propFloatCallbacksLock.unlock();
+    for(const auto& callbackEntry: propFloatCallbacks)
+    {
+        if(callbackEntry.second)
+        {
+            callbackEntry.second(propFloat);
+        }
+    }
+}
+
+long TestApiPublisher::subscribeToPropStringChanged(TestApiPropStringPropertyCb callback)
+{
+    auto handleId = m_propStringChangedCallbackNextId++;
+    std::unique_lock<std::shared_timed_mutex> lock(m_propStringCallbacksMutex);
+    m_propStringCallbacks[handleId] = callback;
+    return handleId;
+}
+
+void TestApiPublisher::unsubscribeFromPropStringChanged(long handleId)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propStringCallbacksMutex);
+    m_propStringCallbacks.erase(handleId);
+}
+
+void TestApiPublisher::publishPropStringChanged(const std::string& propString) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropStringChanged(propString);
+    }
+    std::shared_lock<std::shared_timed_mutex> propStringCallbacksLock(m_propStringCallbacksMutex);
+    const auto propStringCallbacks = m_propStringCallbacks;
+    propStringCallbacksLock.unlock();
+    for(const auto& callbackEntry: propStringCallbacks)
+    {
+        if(callbackEntry.second)
+        {
+            callbackEntry.second(propString);
+        }
+    }
+}
+
+long TestApiPublisher::subscribeToSigInt(TestApiSigIntSignalCb callback)
+{
+    // this is a short term workaround - we need a better solution for unique handle identifiers
+    auto handleId = m_sigIntSignalCallbackNextId++;
+    std::unique_lock<std::shared_timed_mutex> lock(m_sigIntCallbacksMutex);
+    m_sigIntCallbacks[handleId] = callback;
+    return handleId;
+}
+
+void TestApiPublisher::unsubscribeFromSigInt(long handleId)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_sigIntCallbacksMutex);
+    m_sigIntCallbacks.erase(handleId);
+}
+
+void TestApiPublisher::publishSigInt(int paramInt) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onSigInt(paramInt);
+    }
+    std::shared_lock<std::shared_timed_mutex> sigIntCallbacksLock(m_sigIntCallbacksMutex);
+    const auto sigIntCallbacks = m_sigIntCallbacks;
+    sigIntCallbacksLock.unlock();
+    for(const auto& callbackEntry: sigIntCallbacks)
+    {
+        if(callbackEntry.second)
+        {
+            callbackEntry.second(paramInt);
+        }
+    }
+}
+
+long TestApiPublisher::subscribeToSigFloat(TestApiSigFloatSignalCb callback)
+{
+    // this is a short term workaround - we need a better solution for unique handle identifiers
+    auto handleId = m_sigFloatSignalCallbackNextId++;
+    std::unique_lock<std::shared_timed_mutex> lock(m_sigFloatCallbacksMutex);
+    m_sigFloatCallbacks[handleId] = callback;
+    return handleId;
+}
+
+void TestApiPublisher::unsubscribeFromSigFloat(long handleId)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_sigFloatCallbacksMutex);
+    m_sigFloatCallbacks.erase(handleId);
+}
+
+void TestApiPublisher::publishSigFloat(float paramFloat) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onSigFloat(paramFloat);
+    }
+    std::shared_lock<std::shared_timed_mutex> sigFloatCallbacksLock(m_sigFloatCallbacksMutex);
+    const auto sigFloatCallbacks = m_sigFloatCallbacks;
+    sigFloatCallbacksLock.unlock();
+    for(const auto& callbackEntry: sigFloatCallbacks)
+    {
+        if(callbackEntry.second)
+        {
+            callbackEntry.second(paramFloat);
+        }
+    }
+}
+
+long TestApiPublisher::subscribeToSigString(TestApiSigStringSignalCb callback)
+{
+    // this is a short term workaround - we need a better solution for unique handle identifiers
+    auto handleId = m_sigStringSignalCallbackNextId++;
+    std::unique_lock<std::shared_timed_mutex> lock(m_sigStringCallbacksMutex);
+    m_sigStringCallbacks[handleId] = callback;
+    return handleId;
+}
+
+void TestApiPublisher::unsubscribeFromSigString(long handleId)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_sigStringCallbacksMutex);
+    m_sigStringCallbacks.erase(handleId);
+}
+
+void TestApiPublisher::publishSigString(const std::string& paramString) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onSigString(paramString);
+    }
+    std::shared_lock<std::shared_timed_mutex> sigStringCallbacksLock(m_sigStringCallbacksMutex);
+    const auto sigStringCallbacks = m_sigStringCallbacks;
+    sigStringCallbacksLock.unlock();
+    for(const auto& callbackEntry: sigStringCallbacks)
+    {
+        if(callbackEntry.second)
+        {
+            callbackEntry.second(paramString);
+        }
+    }
+}
+

--- a/performance/testApi/modules/api_module/api/generated/core/testapi.publisher.h
+++ b/performance/testApi/modules/api_module/api/generated/core/testapi.publisher.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include "api/generated/api/datastructs.api.h"
+#include "api/generated/api/testapi.api.h"
+#include "api/generated/api/common.h"
+
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include <shared_mutex>
+
+namespace Test {
+namespace Api {
+
+/**
+ * The implementation of a TestApiPublisher.
+ * Use this class to store clients of the TestApi and inform them about the change
+ * on call of the appropriate publish function.
+ *
+ * @warning This class is thread safe, but the subscribed classes or functions are not protected.
+ */
+class TEST_API_EXPORT TestApiPublisher : public ITestApiPublisher
+{
+public:
+    /**
+    * Implementation of ITestApiPublisher::subscribeToAllChanges
+    */
+    void subscribeToAllChanges(ITestApiSubscriber& subscriber) override;
+    /**
+    * Implementation of ITestApiPublisher::unsubscribeFromAllChanges
+    */
+    void unsubscribeFromAllChanges(ITestApiSubscriber& subscriber) override;
+
+    /**
+    * Implementation of ITestApiPublisher::subscribeToPropIntChanged
+    */
+    long subscribeToPropIntChanged(TestApiPropIntPropertyCb callback) override;
+    /**
+    * Implementation of ITestApiPublisher::subscribeToPropIntChanged
+    */
+    void unsubscribeFromPropIntChanged(long handleId) override;
+
+    /**
+    * Implementation of ITestApiPublisher::subscribeToPropFloatChanged
+    */
+    long subscribeToPropFloatChanged(TestApiPropFloatPropertyCb callback) override;
+    /**
+    * Implementation of ITestApiPublisher::subscribeToPropFloatChanged
+    */
+    void unsubscribeFromPropFloatChanged(long handleId) override;
+
+    /**
+    * Implementation of ITestApiPublisher::subscribeToPropStringChanged
+    */
+    long subscribeToPropStringChanged(TestApiPropStringPropertyCb callback) override;
+    /**
+    * Implementation of ITestApiPublisher::subscribeToPropStringChanged
+    */
+    void unsubscribeFromPropStringChanged(long handleId) override;
+
+    /**
+    * Implementation of ITestApiPublisher::subscribeToSigInt
+    */
+    long subscribeToSigInt(TestApiSigIntSignalCb callback) override;
+    /**
+    * Implementation of ITestApiPublisher::unsubscribeFromSigInt
+    */
+    void unsubscribeFromSigInt(long handleId) override;
+
+    /**
+    * Implementation of ITestApiPublisher::subscribeToSigFloat
+    */
+    long subscribeToSigFloat(TestApiSigFloatSignalCb callback) override;
+    /**
+    * Implementation of ITestApiPublisher::unsubscribeFromSigFloat
+    */
+    void unsubscribeFromSigFloat(long handleId) override;
+
+    /**
+    * Implementation of ITestApiPublisher::subscribeToSigString
+    */
+    long subscribeToSigString(TestApiSigStringSignalCb callback) override;
+    /**
+    * Implementation of ITestApiPublisher::unsubscribeFromSigString
+    */
+    void unsubscribeFromSigString(long handleId) override;
+
+    /**
+    * Implementation of ITestApiPublisher::publishPropIntChanged
+    */
+    void publishPropIntChanged(int propInt) const override;
+    /**
+    * Implementation of ITestApiPublisher::publishPropFloatChanged
+    */
+    void publishPropFloatChanged(float propFloat) const override;
+    /**
+    * Implementation of ITestApiPublisher::publishPropStringChanged
+    */
+    void publishPropStringChanged(const std::string& propString) const override;
+    /**
+    * Implementation of ITestApiPublisher::publishSigInt
+    */
+    void publishSigInt(int paramInt) const override;
+    /**
+    * Implementation of ITestApiPublisher::publishSigFloat
+    */
+    void publishSigFloat(float paramFloat) const override;
+    /**
+    * Implementation of ITestApiPublisher::publishSigString
+    */
+    void publishSigString(const std::string& paramString) const override;
+private:
+    // Subscribers informed about any property change or signal emitted in TestApi
+    std::vector<std::reference_wrapper<ITestApiSubscriber>> m_allChangesSubscribers;
+    // Mutex for m_allChangesSubscribers
+    mutable std::shared_timed_mutex m_allChangesSubscribersMutex;
+    // Next free unique identifier to subscribe for the PropInt change.
+    std::atomic<long> m_propIntChangedCallbackNextId {0};
+    // Subscribed callbacks for the PropInt change.
+    std::map<long, TestApiPropIntPropertyCb> m_propIntCallbacks;
+    // Mutex for m_propIntCallbacks
+    mutable std::shared_timed_mutex m_propIntCallbacksMutex;
+    // Next free unique identifier to subscribe for the PropFloat change.
+    std::atomic<long> m_propFloatChangedCallbackNextId {0};
+    // Subscribed callbacks for the PropFloat change.
+    std::map<long, TestApiPropFloatPropertyCb> m_propFloatCallbacks;
+    // Mutex for m_propFloatCallbacks
+    mutable std::shared_timed_mutex m_propFloatCallbacksMutex;
+    // Next free unique identifier to subscribe for the PropString change.
+    std::atomic<long> m_propStringChangedCallbackNextId {0};
+    // Subscribed callbacks for the PropString change.
+    std::map<long, TestApiPropStringPropertyCb> m_propStringCallbacks;
+    // Mutex for m_propStringCallbacks
+    mutable std::shared_timed_mutex m_propStringCallbacksMutex;
+    // Next free unique identifier to subscribe for the SigInt emission.
+    std::atomic<long> m_sigIntSignalCallbackNextId {0};
+    // Subscribed callbacks for the SigInt emission.
+    std::map<long, TestApiSigIntSignalCb > m_sigIntCallbacks;
+    // Mutex for m_sigIntSignalCallbackNextId and m_sigIntCallbacks
+    mutable std::shared_timed_mutex m_sigIntCallbacksMutex;
+    // Next free unique identifier to subscribe for the SigFloat emission.
+    std::atomic<long> m_sigFloatSignalCallbackNextId {0};
+    // Subscribed callbacks for the SigFloat emission.
+    std::map<long, TestApiSigFloatSignalCb > m_sigFloatCallbacks;
+    // Mutex for m_sigFloatSignalCallbackNextId and m_sigFloatCallbacks
+    mutable std::shared_timed_mutex m_sigFloatCallbacksMutex;
+    // Next free unique identifier to subscribe for the SigString emission.
+    std::atomic<long> m_sigStringSignalCallbackNextId {0};
+    // Subscribed callbacks for the SigString emission.
+    std::map<long, TestApiSigStringSignalCb > m_sigStringCallbacks;
+    // Mutex for m_sigStringSignalCallbackNextId and m_sigStringCallbacks
+    mutable std::shared_timed_mutex m_sigStringCallbacksMutex;
+};
+
+} // namespace Api
+} // namespace Test

--- a/performance/testApi/modules/api_module/api/generated/core/testapi.threadsafedecorator.cpp
+++ b/performance/testApi/modules/api_module/api/generated/core/testapi.threadsafedecorator.cpp
@@ -1,0 +1,74 @@
+
+
+#include "api/generated/core/testapi.threadsafedecorator.h"
+
+using namespace Test::Api;
+TestApiThreadSafeDecorator::TestApiThreadSafeDecorator(std::shared_ptr<ITestApi> impl)
+    : m_impl(impl)
+{
+}
+int TestApiThreadSafeDecorator::funcInt(int paramInt)
+{
+    return m_impl->funcInt(paramInt);
+}
+
+std::future<int> TestApiThreadSafeDecorator::funcIntAsync(int paramInt)
+{
+    return m_impl->funcIntAsync(paramInt);
+}
+float TestApiThreadSafeDecorator::funcFloat(float paramFloat)
+{
+    return m_impl->funcFloat(paramFloat);
+}
+
+std::future<float> TestApiThreadSafeDecorator::funcFloatAsync(float paramFloat)
+{
+    return m_impl->funcFloatAsync(paramFloat);
+}
+std::string TestApiThreadSafeDecorator::funcString(const std::string& paramString)
+{
+    return m_impl->funcString(paramString);
+}
+
+std::future<std::string> TestApiThreadSafeDecorator::funcStringAsync(const std::string& paramString)
+{
+    return m_impl->funcStringAsync(paramString);
+}
+void TestApiThreadSafeDecorator::setPropInt(int propInt)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propIntMutex);
+    m_impl->setPropInt(propInt);
+}
+
+int TestApiThreadSafeDecorator::getPropInt() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propIntMutex);
+    return m_impl->getPropInt();
+}
+void TestApiThreadSafeDecorator::setPropFloat(float propFloat)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propFloatMutex);
+    m_impl->setPropFloat(propFloat);
+}
+
+float TestApiThreadSafeDecorator::getPropFloat() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propFloatMutex);
+    return m_impl->getPropFloat();
+}
+void TestApiThreadSafeDecorator::setPropString(const std::string& propString)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propStringMutex);
+    m_impl->setPropString(propString);
+}
+
+const std::string& TestApiThreadSafeDecorator::getPropString() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propStringMutex);
+    return m_impl->getPropString();
+}
+
+ITestApiPublisher& TestApiThreadSafeDecorator::_getPublisher() const
+{
+    return m_impl->_getPublisher();
+}

--- a/performance/testApi/modules/api_module/api/generated/core/testapi.threadsafedecorator.h
+++ b/performance/testApi/modules/api_module/api/generated/core/testapi.threadsafedecorator.h
@@ -1,0 +1,110 @@
+
+#pragma once
+#include "api/generated/api/api.h"
+#include "api/generated/api/common.h"
+#include <memory>
+#include <shared_mutex>
+
+namespace Test {
+namespace Api {
+
+/** 
+* @brief The TestApiThreadSafeDecorator can be used to make property access thread safe.
+*
+* Each property is guarded with its own mutex.
+* Multiple read/get operations can occur at the same time but only one write/set operation at a time.
+*
+* Operations are not guarded by default since the function logic can be too complex than to simply lock it.
+* However, functions can be locked by just adding the same mechanism in the implementation file of
+* the TestApi interface.
+* @see TestApi
+*
+\code{.cpp}
+using namespace Test::Api;
+
+std::unique_ptr<ITestApi> testTestApi = std::make_unique<TestApiThreadSafeDecorator>(std::make_shared<TestApi>());
+
+// Thread safe access
+auto propInt = testTestApi->getPropInt();
+testTestApi->setPropInt(0);
+auto propFloat = testTestApi->getPropFloat();
+testTestApi->setPropFloat(0.0f);
+auto propString = testTestApi->getPropString();
+testTestApi->setPropString(std::string());
+\endcode
+*/
+class TEST_API_EXPORT TestApiThreadSafeDecorator : public ITestApi
+{
+public:
+    /** 
+    * ctor
+    * @param impl The TestApi object to make thread safe.
+    */
+    explicit TestApiThreadSafeDecorator(std::shared_ptr<ITestApi> impl);
+
+    /** 
+    * Forwards call to TestApi implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    int funcInt(int paramInt) override;
+    /** 
+    * Forwards call to TestApi implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<int> funcIntAsync(int paramInt) override;
+
+    /** 
+    * Forwards call to TestApi implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    float funcFloat(float paramFloat) override;
+    /** 
+    * Forwards call to TestApi implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<float> funcFloatAsync(float paramFloat) override;
+
+    /** 
+    * Forwards call to TestApi implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::string funcString(const std::string& paramString) override;
+    /** 
+    * Forwards call to TestApi implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<std::string> funcStringAsync(const std::string& paramString) override;
+
+    /** Guards and forwards call to TestApi implementation. */
+    void setPropInt(int propInt) override;
+    /** Guards and forwards call to TestApi implementation. */
+    int getPropInt() const override;
+
+    /** Guards and forwards call to TestApi implementation. */
+    void setPropFloat(float propFloat) override;
+    /** Guards and forwards call to TestApi implementation. */
+    float getPropFloat() const override;
+
+    /** Guards and forwards call to TestApi implementation. */
+    void setPropString(const std::string& propString) override;
+    /** Guards and forwards call to TestApi implementation. */
+    const std::string& getPropString() const override;
+
+    /**
+    * Access to a publisher, use it to subscribe for TestApi changes and signal emission.
+    * This call is thread safe.
+    * @return The publisher for TestApi.
+    */
+    ITestApiPublisher& _getPublisher() const override;
+private:
+    /** The TestApi object which is guarded */
+    std::shared_ptr<ITestApi> m_impl;
+    // Mutex for propInt property
+    mutable std::shared_timed_mutex m_propIntMutex;
+    // Mutex for propFloat property
+    mutable std::shared_timed_mutex m_propFloatMutex;
+    // Mutex for propString property
+    mutable std::shared_timed_mutex m_propStringMutex;
+};
+} // namespace Api
+} // namespace Test

--- a/performance/testApi/modules/api_module/api/generated/olink/CMakeLists.txt
+++ b/performance/testApi/modules/api_module/api/generated/olink/CMakeLists.txt
@@ -1,0 +1,48 @@
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(apigear COMPONENTS utilities)
+
+set (SOURCES_OLINK
+    testapiservice.cpp
+    testapiclient.cpp
+)
+add_library(api-olink SHARED ${SOURCES_OLINK})
+add_library(api::api-olink ALIAS api-olink)
+target_include_directories(api-olink
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../../modules>
+    $<INSTALL_INTERFACE:include/api>
+)
+target_link_libraries(api-olink 
+    PUBLIC
+    olink_core
+    apigear::utilities
+    api::api-core
+)
+
+# ensure maximum compiler support
+if(NOT MSVC)
+  target_compile_options(api-olink PRIVATE -Wall -Wextra -Wpedantic -Werror -fvisibility=hidden)
+else()
+  target_compile_options(api-olink PRIVATE /W4 /WX /wd4251)
+endif()
+
+install(TARGETS api-olink
+        EXPORT ApiOLinkTargets
+        RUNTIME DESTINATION bin                 COMPONENT Runtime
+        LIBRARY DESTINATION lib                 COMPONENT Runtime
+        ARCHIVE DESTINATION lib/api   COMPONENT Development)
+# install includes
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include/api/generated FILES_MATCHING PATTERN "*.h")
+
+export(EXPORT ApiOLinkTargets
+  NAMESPACE api::
+)
+
+install(EXPORT ApiOLinkTargets
+  FILE ApiOLinkTargets.cmake
+  DESTINATION ${InstallDir}
+  NAMESPACE api::
+)

--- a/performance/testApi/modules/api_module/api/generated/olink/testapiclient.cpp
+++ b/performance/testApi/modules/api_module/api/generated/olink/testapiclient.cpp
@@ -1,0 +1,244 @@
+
+
+#include "api/generated/olink/testapiclient.h"
+#include "api/generated/core/testapi.publisher.h"
+#include "api/generated/core/api.json.adapter.h"
+
+#include "olink/core/types.h"
+#include "olink/iclientnode.h"
+
+#include "apigear/utilities/logger.h"
+
+using namespace Test::Api;
+using namespace Test::Api::olink;
+
+namespace 
+{
+const std::string interfaceId = "api.TestApi";
+}
+
+TestApiClient::TestApiClient()
+    : m_publisher(std::make_unique<TestApiPublisher>())
+{}
+
+void TestApiClient::applyState(const nlohmann::json& fields) 
+{
+    if(fields.contains("propInt")) {
+        setPropIntLocal(fields["propInt"].get<int>());
+    }
+    if(fields.contains("propFloat")) {
+        setPropFloatLocal(fields["propFloat"].get<float>());
+    }
+    if(fields.contains("propString")) {
+        setPropStringLocal(fields["propString"].get<std::string>());
+    }
+}
+
+void TestApiClient::setPropInt(int propInt)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    m_node->setRemoteProperty(propertyId, propInt);
+}
+
+void TestApiClient::setPropIntLocal(int propInt)
+{
+    if (m_data.m_propInt != propInt) {
+        m_data.m_propInt = propInt;
+        m_publisher->publishPropIntChanged(propInt);
+    }
+}
+
+int TestApiClient::getPropInt() const
+{
+    return m_data.m_propInt;
+}
+
+void TestApiClient::setPropFloat(float propFloat)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
+    m_node->setRemoteProperty(propertyId, propFloat);
+}
+
+void TestApiClient::setPropFloatLocal(float propFloat)
+{
+    if (m_data.m_propFloat != propFloat) {
+        m_data.m_propFloat = propFloat;
+        m_publisher->publishPropFloatChanged(propFloat);
+    }
+}
+
+float TestApiClient::getPropFloat() const
+{
+    return m_data.m_propFloat;
+}
+
+void TestApiClient::setPropString(const std::string& propString)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
+    m_node->setRemoteProperty(propertyId, propString);
+}
+
+void TestApiClient::setPropStringLocal(const std::string& propString)
+{
+    if (m_data.m_propString != propString) {
+        m_data.m_propString = propString;
+        m_publisher->publishPropStringChanged(propString);
+    }
+}
+
+const std::string& TestApiClient::getPropString() const
+{
+    return m_data.m_propString;
+}
+
+int TestApiClient::funcInt(int paramInt)
+{
+     if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return 0;
+    }
+    int value(funcIntAsync(paramInt).get());
+    return value;
+}
+
+std::future<int> TestApiClient::funcIntAsync(int paramInt)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<int>{};
+    }
+    return std::async(std::launch::async, [this,
+                    paramInt]()
+        {
+            std::promise<int> resultPromise;
+            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
+            m_node->invokeRemote(operationId,
+                nlohmann::json::array({paramInt}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    const int& value = arg.value.get<int>();
+                    resultPromise.set_value(value);
+                });
+            return resultPromise.get_future().get();
+        }
+    );
+}
+
+float TestApiClient::funcFloat(float paramFloat)
+{
+     if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return 0.0f;
+    }
+    float value(funcFloatAsync(paramFloat).get());
+    return value;
+}
+
+std::future<float> TestApiClient::funcFloatAsync(float paramFloat)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<float>{};
+    }
+    return std::async(std::launch::async, [this,
+                    paramFloat]()
+        {
+            std::promise<float> resultPromise;
+            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
+            m_node->invokeRemote(operationId,
+                nlohmann::json::array({paramFloat}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    const float& value = arg.value.get<float>();
+                    resultPromise.set_value(value);
+                });
+            return resultPromise.get_future().get();
+        }
+    );
+}
+
+std::string TestApiClient::funcString(const std::string& paramString)
+{
+     if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::string();
+    }
+    std::string value(funcStringAsync(paramString).get());
+    return value;
+}
+
+std::future<std::string> TestApiClient::funcStringAsync(const std::string& paramString)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<std::string>{};
+    }
+    return std::async(std::launch::async, [this,
+                    paramString]()
+        {
+            std::promise<std::string> resultPromise;
+            const auto& operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
+            m_node->invokeRemote(operationId,
+                nlohmann::json::array({paramString}), [&resultPromise](ApiGear::ObjectLink::InvokeReplyArg arg) {
+                    const std::string& value = arg.value.get<std::string>();
+                    resultPromise.set_value(value);
+                });
+            return resultPromise.get_future().get();
+        }
+    );
+}
+
+std::string TestApiClient::olinkObjectName()
+{
+    return interfaceId;
+}
+
+void TestApiClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+{
+    const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
+    if(signalName == "sigInt") {
+        m_publisher->publishSigInt(args[0].get<int>());   
+        return;
+    }
+    if(signalName == "sigFloat") {
+        m_publisher->publishSigFloat(args[0].get<float>());   
+        return;
+    }
+    if(signalName == "sigString") {
+        m_publisher->publishSigString(args[0].get<std::string>());   
+        return;
+    }
+}
+
+void TestApiClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+{
+    applyState({ {ApiGear::ObjectLink::Name::getMemberName(propertyId), value} });
+}
+void TestApiClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+{
+    m_node = node;
+    applyState(props);
+}
+
+void TestApiClient::olinkOnRelease()
+{
+    m_node = nullptr;
+}
+
+bool TestApiClient::isReady() const
+{
+    return m_node != nullptr;
+}
+
+ITestApiPublisher& TestApiClient::_getPublisher() const
+{
+    return *m_publisher;
+}

--- a/performance/testApi/modules/api_module/api/generated/olink/testapiclient.h
+++ b/performance/testApi/modules/api_module/api/generated/olink/testapiclient.h
@@ -1,0 +1,169 @@
+
+#pragma once
+
+#include "api/generated/api/common.h"
+#include "api/generated/api/api.h"
+#include "api/generated/core/testapi.data.h"
+
+#include "olink/iobjectsink.h"
+
+#include <future>
+#include <memory>
+
+namespace ApiGear{
+namespace ObjectLink{
+class IClientNode;
+}
+}
+
+namespace Test {
+namespace Api {
+namespace olink {
+/**
+* Adapts the general OLink Client handler to a TestApi publisher in a way it provides access 
+* to remote TestApi services. 
+* Sends and receives data over the network with ObjectLink protocol, through the communication node. 
+* see https://objectlinkprotocol.net for ObjectLink details.
+* see https://github.com/apigear-io/objectlink-core-cpp.git for olink client node - abstraction over the network.
+* see Apigear::ObjectLink::OLinkConnection for Olink Client Handler implementation.
+*     It provides a network implementation and tools to connect TestApiClient to it.
+* Use on client side to request changes of the TestApi on the server side 
+* and to subscribe for the TestApi changes.
+*/
+class TEST_API_EXPORT TestApiClient : public ITestApi,
+    public ApiGear::ObjectLink::IObjectSink
+{
+public:
+
+    /** ctor */
+    explicit TestApiClient();
+    /** dtor */
+    virtual ~TestApiClient() = default;
+    /**
+    * Property getter
+    * @return Locally stored locally value for PropInt.
+    */
+    int getPropInt() const override;
+    /**
+    * Request setting a property on the TestApi service.
+    * @param The value to which set request is send for the PropInt.
+    */
+    void setPropInt(int propInt) override;
+    /**
+    * Property getter
+    * @return Locally stored locally value for PropFloat.
+    */
+    float getPropFloat() const override;
+    /**
+    * Request setting a property on the TestApi service.
+    * @param The value to which set request is send for the PropFloat.
+    */
+    void setPropFloat(float propFloat) override;
+    /**
+    * Property getter
+    * @return Locally stored locally value for PropString.
+    */
+    const std::string& getPropString() const override;
+    /**
+    * Request setting a property on the TestApi service.
+    * @param The value to which set request is send for the PropString.
+    */
+    void setPropString(const std::string& propString) override;
+    /**
+    * Remote call of ITestApi::funcInt on the TestApi service.
+    * Uses funcIntAsync
+    */
+    int funcInt(int paramInt) override;
+    /**
+    * Remote call of ITestApi::funcInt on the TestApi service.
+    */
+    std::future<int> funcIntAsync(int paramInt) override;
+    /**
+    * Remote call of ITestApi::funcFloat on the TestApi service.
+    * Uses funcFloatAsync
+    */
+    float funcFloat(float paramFloat) override;
+    /**
+    * Remote call of ITestApi::funcFloat on the TestApi service.
+    */
+    std::future<float> funcFloatAsync(float paramFloat) override;
+    /**
+    * Remote call of ITestApi::funcString on the TestApi service.
+    * Uses funcStringAsync
+    */
+    std::string funcString(const std::string& paramString) override;
+    /**
+    * Remote call of ITestApi::funcString on the TestApi service.
+    */
+    std::future<std::string> funcStringAsync(const std::string& paramString) override;
+
+    /** The publisher to subscribe to. */
+    ITestApiPublisher& _getPublisher() const override;
+    
+    /**
+    * Informs if the TestApiClient is ready to send and receive messages.
+    * @return true if TestApi is operable, false otherwise.
+    */
+    bool isReady() const;
+
+    /**
+    * The name of the object for which this sink is created, object on server side has to have the same name.
+    * It serves as an identifier for the client registry, it has to be unique for the pair sink object - client node.
+    * Passed in the olink messages as an object identifier.
+    */
+    std::string olinkObjectName() override;
+    
+    /**
+    * Information about signal emission on a server side to all subscribers.
+    * @param signalId Unique identifier for the signal emitted from object.
+    * @param args The arguments for the signal.
+    */
+    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    
+    /**
+    * Applies the information about the property changed on server side.
+    * @param propertyId Unique identifier of a changed property in object .
+    * @param value The value of the property.
+    */
+    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    
+    /** Informs this object sink that connection was is established.
+    * @param interfaceId The name of the object for which link was established.
+    * @param props Initial values obtained from the TestApi service
+    * @param the initialized link endpoint for this sink.
+    */
+    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    /**
+    * Informs this object source that the link was disconnected and cannot be used anymore.
+    */
+    void olinkOnRelease() override;
+
+private:
+    /**
+    * Applies received data to local state and publishes changes to subscribers.
+    * @param the data received from TestApi service.
+    */
+    void applyState(const nlohmann::json& fields);
+    /**  Updates local value for PropInt and informs subscriber about the change*/
+    void setPropIntLocal(int propInt);
+    /**  Updates local value for PropFloat and informs subscriber about the change*/
+    void setPropFloatLocal(float propFloat);
+    /**  Updates local value for PropString and informs subscriber about the change*/
+    void setPropStringLocal(const std::string& propString);
+
+    /** Local storage for properties values. */
+    TestApiData m_data;
+
+    /** 
+    * An abstraction layer over the connection with service for the TestApiClient.
+    * Handles incoming and outgoing messages.
+    * Is given when object is linked with the service.
+    */
+    ApiGear::ObjectLink::IClientNode* m_node = nullptr;
+
+    /** The publisher for TestApi */
+    std::unique_ptr<ITestApiPublisher> m_publisher;
+};
+} // namespace olink
+} // namespace Api
+} // namespace Test

--- a/performance/testApi/modules/api_module/api/generated/olink/testapiservice.cpp
+++ b/performance/testApi/modules/api_module/api/generated/olink/testapiservice.cpp
@@ -1,0 +1,156 @@
+
+
+#include "api/generated/api/datastructs.api.h"
+#include "api/generated/olink/testapiservice.h"
+#include "api/generated/core/api.json.adapter.h"
+
+#include "olink/iremotenode.h"
+#include "olink/remoteregistry.h"
+#include "olink/core/types.h"
+#include "apigear/utilities/logger.h"
+
+#include <iostream>
+
+
+using namespace Test::Api;
+using namespace Test::Api::olink;
+
+namespace 
+{
+const std::string interfaceId = "api.TestApi";
+}
+
+TestApiService::TestApiService(std::shared_ptr<ITestApi> TestApi, ApiGear::ObjectLink::RemoteRegistry& registry)
+    : m_TestApi(TestApi)
+    , m_registry(registry)
+{
+    m_TestApi->_getPublisher().subscribeToAllChanges(*this);
+}
+
+TestApiService::~TestApiService()
+{
+    m_TestApi->_getPublisher().unsubscribeFromAllChanges(*this);
+}
+
+std::string TestApiService::olinkObjectName() {
+    return interfaceId;
+}
+
+nlohmann::json TestApiService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+    AG_LOG_DEBUG("TestApiService invoke " + methodId);
+    const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    if(memberMethod == "funcInt") {
+        const int& paramInt = fcnArgs.at(0);
+        int result = m_TestApi->funcInt(paramInt);
+        return result;
+    }
+    if(memberMethod == "funcFloat") {
+        const float& paramFloat = fcnArgs.at(0);
+        float result = m_TestApi->funcFloat(paramFloat);
+        return result;
+    }
+    if(memberMethod == "funcString") {
+        const std::string& paramString = fcnArgs.at(0);
+        std::string result = m_TestApi->funcString(paramString);
+        return result;
+    }
+    return nlohmann::json();
+}
+
+void TestApiService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+    AG_LOG_DEBUG("TestApiService set property " + propertyId);
+    const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
+    if(memberProperty == "propInt") {
+        int propInt = value.get<int>();
+        m_TestApi->setPropInt(propInt);
+    }
+    if(memberProperty == "propFloat") {
+        float propFloat = value.get<float>();
+        m_TestApi->setPropFloat(propFloat);
+    }
+    if(memberProperty == "propString") {
+        std::string propString = value.get<std::string>();
+        m_TestApi->setPropString(propString);
+    } 
+}
+
+void TestApiService::olinkLinked(const std::string& objectId, ApiGear::ObjectLink::IRemoteNode* /*node*/) {
+    AG_LOG_DEBUG("TestApiService linked " + objectId);
+}
+
+void TestApiService::olinkUnlinked(const std::string& objectId){
+    AG_LOG_DEBUG("TestApiService unlinked " + objectId);
+}
+
+nlohmann::json TestApiService::olinkCollectProperties()
+{
+    return nlohmann::json::object({
+        { "propInt", m_TestApi->getPropInt() },
+        { "propFloat", m_TestApi->getPropFloat() },
+        { "propString", m_TestApi->getPropString() }
+    });
+}
+void TestApiService::onSigInt(int paramInt)
+{
+    const nlohmann::json args = { paramInt };
+    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
+    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifySignal(signalId, args);
+        }
+    }
+}
+void TestApiService::onSigFloat(float paramFloat)
+{
+    const nlohmann::json args = { paramFloat };
+    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
+    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifySignal(signalId, args);
+        }
+    }
+}
+void TestApiService::onSigString(const std::string& paramString)
+{
+    const nlohmann::json args = { paramString };
+    const auto& signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
+    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(signalId))) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifySignal(signalId, args);
+        }
+    }
+}
+void TestApiService::onPropIntChanged(int propInt)
+{
+    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propInt);
+        }
+    }
+}
+void TestApiService::onPropFloatChanged(float propFloat)
+{
+    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
+    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propFloat);
+        }
+    }
+}
+void TestApiService::onPropStringChanged(const std::string& propString)
+{
+    const auto& propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
+    for(auto node: m_registry.getNodes(ApiGear::ObjectLink::Name::getObjectId(propertyId))) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propString);
+        }
+    }
+}
+

--- a/performance/testApi/modules/api_module/api/generated/olink/testapiservice.h
+++ b/performance/testApi/modules/api_module/api/generated/olink/testapiservice.h
@@ -1,0 +1,109 @@
+
+#pragma once
+
+#include "api/generated/api/api.h"
+#include "api/generated/api/common.h"
+#include "olink/iobjectsource.h"
+
+
+namespace ApiGear {
+namespace ObjectLink {
+
+class RemoteRegistry;
+class IRemoteNode;
+
+}} //namespace ApiGear::ObjectLink
+
+namespace Test {
+namespace Api {
+namespace olink {
+/**
+* Server side for TestApi implements the TestApi service.
+* It is a source of data for TestApi clients.
+* Sends and receives data over the network with ObjectLink protocol. 
+* see https://objectlinkprotocol.net for Object Link Details
+*/
+class TEST_API_EXPORT TestApiService : public ApiGear::ObjectLink::IObjectSource, public ITestApiSubscriber
+{
+public:
+    /**
+    * ctor
+    * @param TestApi The service source object, the actual TestApi object which is exposed for remote clients with olink.
+    * @param registry The global registry that keeps track of the object source services associated with network nodes.
+    */
+    explicit TestApiService(std::shared_ptr<ITestApi> TestApi, ApiGear::ObjectLink::RemoteRegistry& registry);
+    virtual ~TestApiService() override;
+
+    /**
+    * The name of the object for which this service is created, object on client side has to have the same name.
+    * It serves as an identifier for the source registry, it has to be unique for the pair source object - remote node.
+    * Passed in the olink messages as an object identifier.
+    */
+    std::string olinkObjectName() override;
+    /**
+    * Applies received method invocation with given arguments on the TestApi object.
+    * @param name Path of the method to invoke. Contains object name and the method name.
+    * @param args Arguments required to invoke a method in json format.
+    * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
+    */
+    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    /**
+    * Applies received change property request to TestApi object.
+    * @param name Path the property to change. Contains object name and the property name.
+    * @param args Value in json format requested to set for the property.
+    */
+    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    /**
+    * Informs this service source that the link was established.
+    * @param name The name of the object for which link was established.
+    * @param the initialized link endpoint.
+    */
+    void olinkLinked(const std::string& objectId, ApiGear::ObjectLink::IRemoteNode *node) override;
+    /**
+    * Informs this service source that the link was disconnected and cannot be used anymore.
+    */
+    void olinkUnlinked(const std::string& objectId) override;
+
+    /**
+    * Gets the current state of TestApi object.
+    * @return the set of properties with their current values for the TestApi object in json format.
+    */
+    nlohmann::json olinkCollectProperties() override;
+    /**
+    * Forwards emitted sigInt through network if the connection is established.
+    */
+    void onSigInt(int paramInt) override;
+    /**
+    * Forwards emitted sigFloat through network if the connection is established.
+    */
+    void onSigFloat(float paramFloat) override;
+    /**
+    * Forwards emitted sigString through network if the connection is established.
+    */
+    void onSigString(const std::string& paramString) override;
+    /**
+    * Forwards propInt change through network if the connection is established.
+    */
+    void onPropIntChanged(int propInt) override;
+    /**
+    * Forwards propFloat change through network if the connection is established.
+    */
+    void onPropFloatChanged(float propFloat) override;
+    /**
+    * Forwards propString change through network if the connection is established.
+    */
+    void onPropStringChanged(const std::string& propString) override;
+
+private:
+    /**
+    * The TestApi used for object source.
+    */
+    std::shared_ptr<ITestApi> m_TestApi;
+    /**
+    * A global registry that keeps track of object sources associated with their network layer nodes.
+    */
+    ApiGear::ObjectLink::RemoteRegistry& m_registry;
+};
+} // namespace olink
+} // namespace Api
+} // namespace Test

--- a/performance/testApi/modules/api_module/api/implementation/CMakeLists.txt
+++ b/performance/testApi/modules/api_module/api/implementation/CMakeLists.txt
@@ -1,0 +1,46 @@
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+set (SOURCES_CORE_IMPL
+    testapi.cpp
+)
+add_library(api-implementation SHARED ${SOURCES_CORE_IMPL})
+add_library(api::api-implementation ALIAS api-implementation)
+target_include_directories(api-implementation
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../modules>
+    $<INSTALL_INTERFACE:include/api>
+)
+target_link_libraries(api-implementation PUBLIC api::api-api api::api-core Threads::Threads)
+# ensure maximum compiler support
+if(NOT MSVC)
+  target_compile_options(api-implementation PRIVATE -Wall -Wextra -Wpedantic -Werror -fvisibility=hidden)
+else()
+  target_compile_options(api-implementation PRIVATE /W4 /WX /wd4251)
+endif()
+
+install(TARGETS api-implementation
+        EXPORT ApiImplementationTargets
+        RUNTIME DESTINATION bin                 COMPONENT Runtime
+        LIBRARY DESTINATION lib                 COMPONENT Runtime
+        ARCHIVE DESTINATION lib/api   COMPONENT Development)
+# install includes
+FILE(GLOB Api_INCLUDES *.h)
+install(FILES ${Api_INCLUDES}
+        DESTINATION include/api)
+
+export(EXPORT ApiImplementationTargets
+  NAMESPACE api::
+)
+
+install(EXPORT ApiImplementationTargets
+  FILE ApiImplementationTargets.cmake
+  DESTINATION ${InstallDir}
+  NAMESPACE api::
+)

--- a/performance/testApi/modules/api_module/api/implementation/testapi.cpp
+++ b/performance/testApi/modules/api_module/api/implementation/testapi.cpp
@@ -1,0 +1,110 @@
+
+
+#include "api/implementation/testapi.h"
+#include "api/generated/core/testapi.publisher.h"
+#include "api/generated/core/testapi.data.h"
+
+using namespace Test::Api;
+
+TestApi::TestApi()
+    : m_publisher(std::make_unique<TestApiPublisher>())
+{
+}
+TestApi::~TestApi()
+{
+}
+
+void TestApi::setPropInt(int propInt)
+{
+    if (m_data.m_propInt != propInt) {
+        m_data.m_propInt = propInt;
+        m_publisher->publishPropIntChanged(propInt);
+    }
+}
+
+int TestApi::getPropInt() const
+{
+    return m_data.m_propInt;
+}
+
+void TestApi::setPropFloat(float propFloat)
+{
+    if (m_data.m_propFloat != propFloat) {
+        m_data.m_propFloat = propFloat;
+        m_publisher->publishPropFloatChanged(propFloat);
+    }
+}
+
+float TestApi::getPropFloat() const
+{
+    return m_data.m_propFloat;
+}
+
+void TestApi::setPropString(const std::string& propString)
+{
+    if (m_data.m_propString != propString) {
+        m_data.m_propString = propString;
+        m_publisher->publishPropStringChanged(propString);
+    }
+}
+
+const std::string& TestApi::getPropString() const
+{
+    return m_data.m_propString;
+}
+
+int TestApi::funcInt(int paramInt)
+{
+    (void) paramInt; // suppress the 'Unreferenced Formal Parameter' warning.
+    // do business logic here
+    return 0;
+}
+
+std::future<int> TestApi::funcIntAsync(int paramInt)
+{
+    return std::async(std::launch::async, [this,
+                    paramInt]()
+        {
+            return funcInt(paramInt);
+        }
+    );
+}
+
+float TestApi::funcFloat(float paramFloat)
+{
+    (void) paramFloat; // suppress the 'Unreferenced Formal Parameter' warning.
+    // do business logic here
+    return 0.0f;
+}
+
+std::future<float> TestApi::funcFloatAsync(float paramFloat)
+{
+    return std::async(std::launch::async, [this,
+                    paramFloat]()
+        {
+            return funcFloat(paramFloat);
+        }
+    );
+}
+
+std::string TestApi::funcString(const std::string& paramString)
+{
+    (void) paramString; // suppress the 'Unreferenced Formal Parameter' warning.
+    // do business logic here
+    return std::string();
+}
+
+std::future<std::string> TestApi::funcStringAsync(const std::string& paramString)
+{
+    return std::async(std::launch::async, [this,
+                    paramString]()
+        {
+            return funcString(paramString);
+        }
+    );
+}
+
+ITestApiPublisher& TestApi::_getPublisher() const
+{
+    return *m_publisher;
+}

--- a/performance/testApi/modules/api_module/api/implementation/testapi.h
+++ b/performance/testApi/modules/api_module/api/implementation/testapi.h
@@ -1,0 +1,50 @@
+
+#pragma once
+#include "api/generated/api/api.h"
+#include "api/generated/api/common.h"
+#include "api/generated/core/testapi.data.h"
+#include <memory>
+
+namespace Test {
+namespace Api {
+
+/**
+* The TestApi implementation.
+*/
+class TEST_API_EXPORT TestApi : public ITestApi
+{
+public:
+    explicit TestApi();
+    ~TestApi();
+public:
+    void setPropInt(int propInt) override;
+    int getPropInt() const override;
+    
+    void setPropFloat(float propFloat) override;
+    float getPropFloat() const override;
+    
+    void setPropString(const std::string& propString) override;
+    const std::string& getPropString() const override;
+    
+    int funcInt(int paramInt) override;
+    std::future<int> funcIntAsync(int paramInt) override;
+        
+    float funcFloat(float paramFloat) override;
+    std::future<float> funcFloatAsync(float paramFloat) override;
+        
+    std::string funcString(const std::string& paramString) override;
+    std::future<std::string> funcStringAsync(const std::string& paramString) override;
+        
+    /**
+    * Access to a publisher, use it to subscribe for TestApi changes and signal emission.
+    * @return The publisher for TestApi.
+    */
+    ITestApiPublisher& _getPublisher() const override;
+private:
+    /** The publisher for the TestApi. */
+    std::unique_ptr<ITestApiPublisher> m_publisher;
+    /** The helper structure to store all the properties for TestApi. */
+    TestApiData m_data;
+};
+} // namespace Api
+} // namespace Test

--- a/performance/test_client_node.cpp
+++ b/performance/test_client_node.cpp
@@ -1,0 +1,94 @@
+#include "api/generated/olink/testapiclient.h"
+#include "olink/clientnode.h"
+#include "olink/clientregistry.h"
+#include "olink/core/types.h"
+#include <memory>
+#include <chrono>
+#include <iostream>
+#include <algorithm>
+
+
+class TestSink : public Test::Api::olink::TestApiClient
+{
+public:
+    TestSink(std::string name)
+    :m_name(name)
+    {}
+
+    std::string olinkObjectName() override {return m_name;}
+    std::string m_name;
+};
+
+namespace {
+    ApiGear::ObjectLink::MessageConverter converter(ApiGear::ObjectLink::MessageFormat::JSON);
+}
+
+
+/*
+* Test to check bottle necks for the client registry
+* Test attaches sink_number of sinks - adds them to registry and requests linking for them.
+* Then the init message is sent to test client node.
+* Then for each sink a messages_number number of int property change requests are sent.
+* At the end of test all of the sinks are unlinked.
+* The write function is set to do nothing. Normally the network layer sets here a handle to send the messages.
+*/
+int main()
+{
+    std::vector<uint16_t> time;
+    auto repeat_test_count = 10u;
+    auto sink_number = 500u;
+    auto messages_number = 1000u;
+
+    // Prepare sinks and init messages for them.
+    std::vector<std::shared_ptr<TestSink>> sinks;
+    nlohmann::json initProperties = {};
+    std::map<std::string, nlohmann::json> initMessages;
+    for (auto i = 0u; i < sink_number; i++)
+    {
+        auto sink = std::make_shared<TestSink>("Sink" + std::to_string(i));
+        auto InitMessage = ApiGear::ObjectLink::Protocol::initMessage(sink->olinkObjectName(), {});
+        initMessages[sink->olinkObjectName()] = converter.toString(InitMessage);
+        sinks.push_back(sink);
+    }
+
+
+    // start test
+    for (auto count = 0u; count < repeat_test_count; count++)
+    {
+        ApiGear::ObjectLink::ClientRegistry registry;
+        auto testedNode = ApiGear::ObjectLink::ClientNode::create(registry);
+        // Set empty messages sender.
+        testedNode->onWrite([](const auto& /*msg*/){/*do nothing with the sent message*/ });
+        auto begin = std::chrono::high_resolution_clock::now();
+        {
+            for (auto sink : sinks)
+            {
+                registry.addSink(sink);
+                auto sinkName = sink->olinkObjectName();
+                testedNode->linkRemote(sinkName);
+                testedNode->handleMessage(initMessages.at(sinkName));
+            }
+            for (auto sink : sinks)
+            {
+                for ( auto i = 0u; i < messages_number; i++)
+                {
+                   sink->setPropInt(i);
+                }
+                testedNode->unlinkRemote(sink->olinkObjectName());
+            }
+
+        }
+
+        auto end = std::chrono::high_resolution_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - begin);
+        time.push_back(elapsed.count());
+    }
+
+    std::cout<<"average time measured "<< std::accumulate(time.begin(), time.end(), 0.0) / time.size()<< std::endl;
+    auto max = std::max_element(time.begin(), time.end());
+    auto min = std::min_element(time.begin(), time.end());
+    std::cout<<"lowest time measured "<< *min << std::endl;
+    std::cout<<"highest time measured "<< *max << std::endl;
+    
+    return 0;
+}

--- a/performance/test_remote_node.cpp
+++ b/performance/test_remote_node.cpp
@@ -1,0 +1,106 @@
+#include "olink/iobjectsource.h"
+#include "olink/remotenode.h"
+#include "api/generated/olink/testapiservice.h"
+#include "api/implementation/testapi.h"
+#include "olink/remoteregistry.h"
+#include "olink/core/types.h"
+#include <memory>
+#include <chrono>
+#include <iostream>
+#include <algorithm>
+
+namespace {
+
+    // Converter used in tests, should be same as one used by node.
+    ApiGear::ObjectLink::MessageConverter converter(ApiGear::ObjectLink::MessageFormat::JSON);
+}
+
+
+class TestService : public Test::Api::olink::TestApiService
+{
+public:
+    TestService(std::string name, std::shared_ptr<Test::Api::ITestApi> TestApi, ApiGear::ObjectLink::RemoteRegistry& registry)
+        :TestApiService(TestApi, registry),
+        m_name(name)
+    {}
+
+    std::string olinkObjectName() override {
+        return m_name;
+    }
+    std::string m_name;
+};
+
+/*
+* Test to check bottle necks for the remote registry
+* Test attaches source_number - adds them to registry and sends the link message to tested remote node
+* Then for each source a messages_number is sent with changing the int property to value of current number of a message to sent
+* Then for each source the unregister message is sent to tested remote node.
+*/
+int main()
+{
+    auto repeat_test_count = 1u;
+    std::vector<uint16_t> time;
+    auto source_number = 500u;
+    auto messages_number = 1000u;
+
+    for (auto count = 0u; count < repeat_test_count; count++)
+    {
+        std::vector<std::shared_ptr<Test::Api::TestApi>> sources;
+        std::vector<std::shared_ptr<TestService>> services;
+        std::map<std::string, nlohmann::json> linkMessages;
+        std::map<std::string, nlohmann::json> unlinkMessages;
+        ApiGear::ObjectLink::RemoteRegistry registry;
+        //prepare a service and all it requires for test:
+        // source
+        // link message which will be sent during test
+        // unlink message which will be sent during test
+        // put a source to registry
+        for (auto i = 0u; i < source_number; i++)
+        {
+            auto source = std::make_shared<Test::Api::TestApi>();
+            auto sourceService = std::make_shared<TestService>("Source" + std::to_string(i), source, registry);
+            auto linkMessage = ApiGear::ObjectLink::Protocol::linkMessage(sourceService->olinkObjectName());
+            auto unlinkMessage = ApiGear::ObjectLink::Protocol::unlinkMessage(sourceService->olinkObjectName());
+            linkMessages[sourceService->olinkObjectName()] = converter.toString(linkMessage);
+            unlinkMessages[sourceService->olinkObjectName()] = converter.toString(unlinkMessage);
+            services.push_back(sourceService);
+            sources.push_back(source);
+            registry.addSource(sourceService);
+        }
+
+        // Prepare test remote node, with onWrite that does nothing.
+        auto testedNode = ApiGear::ObjectLink::RemoteNode::createRemoteNode(registry);
+        testedNode->onWrite([](const auto& /*msg*/){/*do nothing with the sent message*/ });
+
+        auto begin = std::chrono::high_resolution_clock::now();
+        {
+            for (auto source : services)
+            {
+                testedNode->handleMessage(linkMessages.at(source->olinkObjectName()));
+            }
+
+            for (auto source : sources)
+            {
+                for (auto i = 0u; i < messages_number; i++)
+                {
+                    source->setPropInt(i);
+                }
+            }
+            for (auto source : services)
+            {
+                testedNode->handleMessage(unlinkMessages.at(source->olinkObjectName()));
+            }
+        }
+        auto end = std::chrono::high_resolution_clock::now();
+
+        auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(end - begin);
+        time.push_back(elapsed.count());
+    }
+
+    std::cout << "average time measured " << std::accumulate(time.begin(), time.end(), 0.0) / time.size() << std::endl;
+    auto max = std::max_element(time.begin(), time.end());
+    auto min = std::min_element(time.begin(), time.end());
+    std::cout << "lowest time measured " << *min << std::endl;
+    std::cout << "highest time measured " << *max << std::endl;
+
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,11 +43,10 @@ SET(OLINK_HEADERS
     )
 
 
-add_library (olink_core STATIC ${OLINK_SOURCES})
-set_property(TARGET olink_core PROPERTY POSITION_INDEPENDENT_CODE ON)
+add_library (olink_core STATIC ${OLINK_SOURCES} ${OLINK_HEADERS})
 
 target_include_directories (olink_core 
-  PUBLIC
+  INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include>
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,10 +43,11 @@ SET(OLINK_HEADERS
     )
 
 
-add_library (olink_core STATIC ${OLINK_SOURCES} ${OLINK_HEADERS})
+add_library (olink_core STATIC ${OLINK_SOURCES})
+set_property(TARGET olink_core PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories (olink_core 
-  INTERFACE
+  PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include>
 )
@@ -65,18 +66,18 @@ endif()
 
 # install binary files
 install(TARGETS olink_core
-        EXPORT objectlink-core-cppConfig
+        EXPORT olink_coreConfig
         RUNTIME DESTINATION bin COMPONENT Runtime
         LIBRARY DESTINATION lib COMPONENT Runtime
-        ARCHIVE DESTINATION lib/objectlink-core-cpp COMPONENT Development)
+        ARCHIVE DESTINATION lib/olink_core COMPONENT Development)
 # install includes
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/olink DESTINATION include FILES_MATCHING PATTERN "*.h")
 include(CMakePackageConfigHelpers)
 export(TARGETS
     olink_core
-    FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/objectlink-core-cppConfig.cmake"
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/olink_coreConfig.cmake"
 )
 install(EXPORT
-    objectlink-core-cppConfig
-    DESTINATION "lib/objectlink-core-cpp/cmake"
+    olink_coreConfig
+    DESTINATION "lib/olink_core/cmake"
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ SET(OLINK_HEADERS
 add_library (olink_core STATIC ${OLINK_SOURCES} ${OLINK_HEADERS})
 
 target_include_directories (olink_core 
-  INTERFACE
+  PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include>
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ set(OLINK_SOURCES
     )
 
 add_library (olink_core STATIC ${OLINK_SOURCES} )
+set_property(TARGET olink_core PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories (olink_core 
   PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,25 +25,7 @@ set(OLINK_SOURCES
     olink/remoteregistry.cpp 
     )
 
-SET(OLINK_HEADERS
-    olink/core/basenode.h
-    olink/core/olink_common.h
-    olink/core/protocol.h
-    olink/core/types.h
-    olink/core/uniqueidobjectstorage.h
-    olink/clientnode.h
-    olink/clientregistry.h
-    olink/consolelogger.h
-    olink/iclientnode.h
-    olink/iobjectsink.h
-    olink/iobjectsource.h
-    olink/iremotenode.h
-    olink/remotenode.h
-    olink/remoteregistry.h
-    )
-
-
-add_library (olink_core STATIC ${OLINK_SOURCES} ${OLINK_HEADERS})
+add_library (olink_core STATIC ${OLINK_SOURCES} )
 
 target_include_directories (olink_core 
   PUBLIC


### PR DESCRIPTION
Adds tests that were run under performance measurement tool to identify bottlenecks.
Tests also measure time which may be some indication. It contains the Api, module which is used to generate sinks and sources and which may be a base for other repositories for performance tests. This is initial task in performance area.
The result is that logging in general should be changed and getNodes for remoteRegistry. Those changes should be addressed with next commits.
