### PR TITLE
fix: protocol safety hardening

### DIFF
--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
 

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -44,3 +44,51 @@ jobs:
 
     - name: Install
       run: cmake --install ${{github.workspace}}/build --prefix tmp
+
+  sanitize-thread:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake with ThreadSanitizer
+      run: >
+        cmake -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=Debug
+        -DCMAKE_CXX_FLAGS="-fsanitize=thread"
+        -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"
+        -DOLINK_CORE_FETCH_DEPS=ON
+        -DOLINK_CORE_BUILD_TESTS=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+        TSAN_OPTIONS: halt_on_error=1
+      run: ctest
+
+  sanitize-address:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake with AddressSanitizer
+      run: >
+        cmake -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=Debug
+        -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
+        -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
+        -DOLINK_CORE_FETCH_DEPS=ON
+        -DOLINK_CORE_BUILD_TESTS=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+        ASAN_OPTIONS: halt_on_error=1
+      run: ctest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.14...3.31)
 project(objectlink-core-cpp LANGUAGES CXX)
 
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(NOT nlohmann_json_FOUND)
   include(FetchContent)
   set(JSON_Install ON)
   FetchContent_Declare(nlohmann_json
-  URL https://github.com/nlohmann/json/releases/download/v3.10.5/json.tar.xz
+  URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
   OVERRIDE_FIND_PACKAGE)
   FetchContent_MakeAvailable(nlohmann_json)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14...3.31)
-project(objectlink-core-cpp LANGUAGES CXX)
+project(objectlink-core-cpp VERSION 0.2.11 LANGUAGES CXX)
 
 include(CTest)
 option(BUILD_EXAMPLES "Build examples" FALSE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,7 @@ configure_package_config_file(
 )
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/olink_coreConfigVersion.cmake
-  VERSION 0.2.9
+  VERSION ${PROJECT_VERSION}
   COMPATIBILITY SameMinorVersion)
 install(EXPORT olink_coreTargets
         FILE olink_coreTargets.cmake

--- a/src/olink/clientnode.cpp
+++ b/src/olink/clientnode.cpp
@@ -151,6 +151,22 @@ void ClientNode::handleError(int msgType, int requestId, const std::string& erro
 {
     static const std::string errorLog = "ClientNode.handleError: ";
     emitLog(LogLevel::Info, errorLog, std::to_string(msgType), std::to_string(requestId), error);
+
+    // Clean up pending invoke if the error relates to an invoke operation.
+    if (msgType == static_cast<int>(MsgType::Invoke) || msgType == static_cast<int>(MsgType::InvokeReply)) {
+        std::unique_lock<std::mutex> lock(m_pendingInvokesMutex);
+        auto responseHandler = m_invokesPending.find(static_cast<unsigned int>(requestId));
+        InvokeReplyFunc callback = nullptr;
+        if (responseHandler != m_invokesPending.end()) {
+            callback = responseHandler->second;
+            m_invokesPending.erase(responseHandler);
+        }
+        lock.unlock();
+        if (callback) {
+            const InvokeReplyArg arg{ std::string(), nlohmann::json() };
+            callback(arg);
+        }
+    }
 }
 
 unsigned int ClientNode::nextRequestId()

--- a/src/olink/clientregistry.cpp
+++ b/src/olink/clientregistry.cpp
@@ -22,8 +22,8 @@ void ClientRegistry::setNode(unsigned long id, const std::string& objectId)
     auto entryForObject = m_entries.find(objectId);
     if (entryForObject == m_entries.end()){
         auto newEntry = SinkToClientEntry();
-        m_entries[objectId] = newEntry;
         newEntry.nodeId = id;
+        m_entries[objectId] = newEntry;
     } else if (entryForObject->second.nodeId == m_clientNodesById.getInvalidId()){
         entryForObject->second.nodeId = id;
     } else if (entryForObject->second.nodeId != id){
@@ -125,6 +125,7 @@ unsigned long ClientRegistry::registerNode(std::weak_ptr<IClientNode> node)
     if (!lockedNode){
         static const std::string invalidNodeLog = "Trying to get node, but it is already gone.";
         emitLog(LogLevel::Warning, invalidNodeLog);
+        return m_clientNodesById.getInvalidId();
     }
     return m_clientNodesById.add(lockedNode);
 }

--- a/src/olink/core/basenode.cpp
+++ b/src/olink/core/basenode.cpp
@@ -10,6 +10,7 @@ static const std::string notImplementedLog = "not implemented ";
 
 void BaseNode::onWrite(WriteMessageFunc func)
 {
+    std::unique_lock<std::mutex> lock(m_nodeMutex);
     m_writeFunc = func;
 }
 
@@ -17,8 +18,19 @@ void BaseNode::emitWrite(const nlohmann::json& msg)
 {
     static const std::string writeMessageLog = "writeMessage: ";
     emitLogWithPayload(LogLevel::Debug, msg, writeMessageLog);
-    if(m_writeFunc) {
-        m_writeFunc(m_converter.toString(msg));
+
+    // Copy the write function and convert under the lock, then call outside
+    WriteMessageFunc writeFuncCopy;
+    std::string converted;
+    {
+        std::unique_lock<std::mutex> lock(m_nodeMutex);
+        writeFuncCopy = m_writeFunc;
+        if (writeFuncCopy) {
+            converted = m_converter.toString(msg);
+        }
+    }
+    if(writeFuncCopy) {
+        writeFuncCopy(converted);
     } else {
         static const std::string noWriterSetLog = "Messages are not sent if the write function is not set";
         emitLog(LogLevel::Warning, noWriterSetLog);
@@ -26,18 +38,39 @@ void BaseNode::emitWrite(const nlohmann::json& msg)
 }
 void BaseNode::setMessageFormat(MessageFormat format)
 {
+    std::unique_lock<std::mutex> lock(m_nodeMutex);
     m_converter.setMessageFormat(format);
 }
 
 void BaseNode::setMaxMessageSize(size_t size)
 {
+    std::unique_lock<std::mutex> lock(m_nodeMutex);
     m_converter.setMaxMessageSize(size);
 }
 
 void BaseNode::handleMessage(const std::string& data)
 {
+    nlohmann::json parsed;
+    std::string convertError;
+    {
+        std::unique_lock<std::mutex> lock(m_nodeMutex);
+        try {
+            parsed = m_converter.fromString(data);
+        } catch (const nlohmann::json::exception& e) {
+            convertError = e.what();
+        } catch (const std::exception& e) {
+            convertError = e.what();
+        }
+    }
+    // Log outside the lock to avoid ABBA deadlock with m_logMutex
+    if (!convertError.empty()) {
+        static const std::string handleMessageErrorLog = "handleMessage exception: ";
+        emitLog(LogLevel::Error, handleMessageErrorLog, convertError);
+        return;
+    }
+    // Protocol dispatch does not need the node mutex - it calls virtual handler methods
     try {
-        m_protocol.handleMessage(m_converter.fromString(data), *this);
+        m_protocol.handleMessage(parsed, *this);
     } catch (const nlohmann::json::exception& e) {
         static const std::string handleMessageErrorLog = "handleMessage json exception: ";
         emitLog(LogLevel::Error, handleMessageErrorLog, std::string(e.what()));

--- a/src/olink/core/basenode.cpp
+++ b/src/olink/core/basenode.cpp
@@ -29,9 +29,22 @@ void BaseNode::setMessageFormat(MessageFormat format)
     m_converter.setMessageFormat(format);
 }
 
+void BaseNode::setMaxMessageSize(size_t size)
+{
+    m_converter.setMaxMessageSize(size);
+}
+
 void BaseNode::handleMessage(const std::string& data)
 {
-    m_protocol.handleMessage(m_converter.fromString(data), *this);
+    try {
+        m_protocol.handleMessage(m_converter.fromString(data), *this);
+    } catch (const nlohmann::json::exception& e) {
+        static const std::string handleMessageErrorLog = "handleMessage json exception: ";
+        emitLog(LogLevel::Error, handleMessageErrorLog, std::string(e.what()));
+    } catch (const std::exception& e) {
+        static const std::string handleMessageErrorLog = "handleMessage exception: ";
+        emitLog(LogLevel::Error, handleMessageErrorLog, std::string(e.what()));
+    }
 }
 
 void BaseNode::handleLink(const std::string& objectId)

--- a/src/olink/core/basenode.h
+++ b/src/olink/core/basenode.h
@@ -5,6 +5,7 @@
 #include "olink_common.h"
 #include "nlohmann/json.hpp"
 #include <cstring>
+#include <mutex>
 
 namespace ApiGear { namespace ObjectLink {
 
@@ -63,6 +64,8 @@ public:
     // Empty, logging only implementation of IProtocolListener::handleError, should be overwritten on both client and server side.
     void handleError(int msgType, int requestId, const std::string& error) override;
 private:
+    /** Mutex protecting m_writeFunc and m_converter */
+    mutable std::mutex m_nodeMutex;
     /** Function with which messages are sent through network after translation to chosen network format */
     WriteMessageFunc m_writeFunc = nullptr;
     /** A message converter, translates messages to and from chosen network format*/

--- a/src/olink/core/basenode.h
+++ b/src/olink/core/basenode.h
@@ -34,6 +34,13 @@ public:
     */
     void setMessageFormat(MessageFormat format);
 
+    /**
+    * Use to set the maximum allowed incoming message size in bytes.
+    * Messages exceeding this limit are rejected before parsing.
+    * Default is 64MB.
+    */
+    void setMaxMessageSize(size_t size);
+
     // Implementation::IMessageHandler
     void handleMessage(const std::string& data) override;
 

--- a/src/olink/core/protocol.cpp
+++ b/src/olink/core/protocol.cpp
@@ -100,37 +100,66 @@ bool Protocol::handleMessage(const nlohmann::json& msg, IProtocolListener& liste
         m_lastError = "message must be array";
         return false;
     }
+    if(msg.size() < 1) {
+        m_lastError = "message array is empty";
+        return false;
+    }
+    try {
     const int msgType = msg[0].get<int>();
     switch(msgType) {
     case int(MsgType::Link): {
+        if(msg.size() < 2) {
+            m_lastError = "truncated Link message";
+            return false;
+        }
         const auto& objectId = msg[1].get<std::string>();
         listener.handleLink(objectId);
         break;
     }
     case int(MsgType::Init): {
+        if(msg.size() < 3) {
+            m_lastError = "truncated Init message";
+            return false;
+        }
         const auto& objectId = msg[1].get<std::string>();
         const auto& props = msg[2].get<nlohmann::json>();
         listener.handleInit(objectId, props);
         break;
     }
     case int(MsgType::Unlink): {
+        if(msg.size() < 2) {
+            m_lastError = "truncated Unlink message";
+            return false;
+        }
         const auto& objectId = msg[1].get<std::string>();
         listener.handleUnlink(objectId);
         break;
     }
     case int(MsgType::SetProperty): {
+        if(msg.size() < 3) {
+            m_lastError = "truncated SetProperty message";
+            return false;
+        }
         const auto& propertyId = msg[1].get<std::string>();
         const auto& value = msg[2].get<nlohmann::json>();
         listener.handleSetProperty(propertyId, value);
         break;
     }
     case int(MsgType::PropertyChange): {
+        if(msg.size() < 3) {
+            m_lastError = "truncated PropertyChange message";
+            return false;
+        }
         const auto& propertyId = msg[1].get<std::string>();
         const auto& value = msg[2].get<nlohmann::json>();
         listener.handlePropertyChange(propertyId, value);
         break;
     }
     case int(MsgType::Invoke): {
+        if(msg.size() < 4) {
+            m_lastError = "truncated Invoke message";
+            return false;
+        }
         const auto& id = msg[1].get<unsigned int>();
         const auto& methodId = msg[2].get<std::string>();
         const auto& args = msg[3].get<nlohmann::json>();
@@ -138,6 +167,10 @@ bool Protocol::handleMessage(const nlohmann::json& msg, IProtocolListener& liste
         break;
     }
     case int(MsgType::InvokeReply): {
+        if(msg.size() < 4) {
+            m_lastError = "truncated InvokeReply message";
+            return false;
+        }
         const auto& id = msg[1].get<unsigned int>();
         const auto& methodId = msg[2].get<std::string>();
         const auto& value = msg[3].get<nlohmann::json>();
@@ -145,12 +178,20 @@ bool Protocol::handleMessage(const nlohmann::json& msg, IProtocolListener& liste
         break;
     }
     case int(MsgType::Signal): {
+        if(msg.size() < 3) {
+            m_lastError = "truncated Signal message";
+            return false;
+        }
         const auto& signalId = msg[1].get<std::string>();
         const auto& args = msg[2].get<nlohmann::json>();
         listener.handleSignal(signalId, args);
         break;
     }
     case int(MsgType::Error): {
+        if(msg.size() < 4) {
+            m_lastError = "truncated Error message";
+            return false;
+        }
         const auto& msgTypeErr = msg[1].get<int>();
         const auto& requestId = msg[2].get<int>();
         const auto& error = msg[3].get<std::string>();
@@ -159,6 +200,10 @@ bool Protocol::handleMessage(const nlohmann::json& msg, IProtocolListener& liste
     }
     default:
         m_lastError = "message not supported: " + msg.dump();
+        return false;
+    }
+    } catch (const nlohmann::json::exception& e) {
+        m_lastError = std::string("message parse error: ") + e.what();
         return false;
     }
     return true;

--- a/src/olink/core/types.cpp
+++ b/src/olink/core/types.cpp
@@ -154,11 +154,13 @@ std::string toString(MsgType type) {
 // ********************************************************************
 
 void LoggerBase::onLog(WriteLogFunc func){
+    std::unique_lock<std::mutex> lock(m_logMutex);
     m_logFunc = func;
 }
 
 void LoggerBase::setLogLevel(LogLevel level)
 {
+    std::unique_lock<std::mutex> lock(m_logMutex);
     m_Loglevel = level;
 }
 

--- a/src/olink/core/types.cpp
+++ b/src/olink/core/types.cpp
@@ -71,20 +71,37 @@ void MessageConverter::setMessageFormat(MessageFormat format)
     m_format = format;
 }
 
+void MessageConverter::setMaxMessageSize(size_t size)
+{
+    m_maxMessageSize = size;
+}
+
 nlohmann::json MessageConverter::fromString(const std::string& message)
 {
-    switch(m_format) {
-    case MessageFormat::JSON:
-        return nlohmann::json::parse(message);
-    case MessageFormat::BSON:
-        return nlohmann::json::from_bson(message);
-    case MessageFormat::MSGPACK:
-        return nlohmann::json::from_msgpack(message);
-    case MessageFormat::CBOR:
-        return nlohmann::json::from_cbor(message);
+    if (message.size() > m_maxMessageSize) {
+        return nlohmann::json();
     }
 
-    return nlohmann::json();
+    nlohmann::json result;
+    switch(m_format) {
+    case MessageFormat::JSON:
+        result = nlohmann::json::parse(message, nullptr, false);
+        break;
+    case MessageFormat::BSON:
+        result = nlohmann::json::from_bson(message, true, false);
+        break;
+    case MessageFormat::MSGPACK:
+        result = nlohmann::json::from_msgpack(message, true, false);
+        break;
+    case MessageFormat::CBOR:
+        result = nlohmann::json::from_cbor(message, true, false);
+        break;
+    }
+
+    if (result.is_discarded()) {
+        return nlohmann::json();
+    }
+    return result;
 }
 
 std::string MessageConverter::toString(const nlohmann::json& j)

--- a/src/olink/core/types.h
+++ b/src/olink/core/types.h
@@ -114,7 +114,7 @@ public:
     /**
     * Unpacks message received from network according to selected message format.
     * @param message A message received from network.
-    * @return Unpacked message in json format.
+    * @return Unpacked message in json format. Returns empty json on parse error or if message exceeds size limit.
     */
     nlohmann::json fromString(const std::string& message);
     /**
@@ -123,9 +123,17 @@ public:
     * @return message in network message format.
     */
     std::string toString(const nlohmann::json& j);
+    /**
+    * Set the maximum allowed message size in bytes.
+    * Messages exceeding this limit will be rejected and an empty json will be returned.
+    * @param size Maximum message size in bytes. Default is 64MB.
+    */
+    void setMaxMessageSize(size_t size);
 private:
     /**Currently used network message format*/
     MessageFormat m_format;
+    /**Maximum allowed message size in bytes (default 64MB)*/
+    size_t m_maxMessageSize = 64 * 1024 * 1024;
 };
 
 /**

--- a/src/olink/core/types.h
+++ b/src/olink/core/types.h
@@ -204,7 +204,7 @@ public:
             if (!m_logFunc || logLevel < m_Loglevel) return;
             logFuncCopy = m_logFunc;
         }
-        const int size = sizeof...(params);
+        constexpr std::size_t size = sizeof...(params);
         std::string arg_list[size] = { params...};
         std::string full_message = "";
         for (const auto& element : arg_list)

--- a/src/olink/core/types.h
+++ b/src/olink/core/types.h
@@ -26,6 +26,7 @@
 #include "olink_common.h"
 #include "nlohmann/json.hpp"
 #include <string>
+#include <mutex>
 
 namespace ApiGear { namespace ObjectLink {
 
@@ -197,18 +198,20 @@ public:
     template<typename ... Parameters>
     void emitLog(LogLevel logLevel, const Parameters&  ...params)
     {
-        if (m_logFunc && logLevel >= m_Loglevel)
+        WriteLogFunc logFuncCopy;
         {
-            const int size = sizeof...(params);
-            std::string arg_list[size] = { params...};
-            std::string full_message = "";
-            for (const auto& element : arg_list)
-            {
-                full_message += element;
-            }
-
-            m_logFunc(logLevel, full_message);
+            std::unique_lock<std::mutex> lock(m_logMutex);
+            if (!m_logFunc || logLevel < m_Loglevel) return;
+            logFuncCopy = m_logFunc;
         }
+        const int size = sizeof...(params);
+        std::string arg_list[size] = { params...};
+        std::string full_message = "";
+        for (const auto& element : arg_list)
+        {
+            full_message += element;
+        }
+        logFuncCopy(logLevel, full_message);
     }
 
     /**
@@ -222,9 +225,11 @@ public:
     template<typename ... Parameters>
     void emitLogWithPayload(LogLevel level, const nlohmann::json& payload, const Parameters&  ...params)
     {
-        if (m_logFunc && level >= m_Loglevel) {
-            emitLog(level, params..., payload.dump());
+        {
+            std::unique_lock<std::mutex> lock(m_logMutex);
+            if (!m_logFunc || level < m_Loglevel) return;
         }
+        emitLog(level, params..., payload.dump());
     }
 
     /*
@@ -233,6 +238,8 @@ public:
     */
     void setLogLevel(LogLevel level);
 private:
+    /** Mutex protecting m_logFunc and m_Loglevel */
+    mutable std::mutex m_logMutex;
     /**
     * User provided function that writes a log into user defined endpoint.
     */

--- a/src/olink/core/uniqueidobjectstorage.h
+++ b/src/olink/core/uniqueidobjectstorage.h
@@ -38,7 +38,10 @@ public:
 
         std::unique_lock<std::mutex> lock(m_mutex);
 
-        if (m_objects.size() == m_maxCount) return invalidId;
+        if (m_objects.size() == m_maxCount) {
+            purgeExpiredLocked();
+            if (m_objects.size() == m_maxCount) return invalidId;
+        }
 
         auto alreadyAddedId = std::find_if(m_objects.begin(), m_objects.end(),
             [lockedObject](const std::pair<const unsigned long, std::weak_ptr<ObjectType>>& current)
@@ -84,7 +87,33 @@ public:
     * @return An id that is considered as invalid in this storage. It is the maximum value of unsigned long.
     */
     unsigned long getInvalidId() const {return invalidId;}
+
+    /*
+    * Removes all expired weak_ptrs from storage, freeing their slots for reuse.
+    * Thread-safe: acquires the internal mutex.
+    */
+    void purgeExpired()
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        purgeExpiredLocked();
+    }
+
 private:
+
+    /**
+    * Removes all expired weak_ptrs from the storage. Must be called with m_mutex held.
+    */
+    void purgeExpiredLocked()
+    {
+        auto it = m_objects.begin();
+        while (it != m_objects.end()) {
+            if (it->second.expired()) {
+                it = m_objects.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
 
     /**
     * Generates a unique id. Must be called with m_mutex held.

--- a/src/olink/core/uniqueidobjectstorage.h
+++ b/src/olink/core/uniqueidobjectstorage.h
@@ -10,6 +10,7 @@
 /*
 * Helper class that stores weak_ptr of ObjectType and assigns it unique Id.
 * The class can be used in multi threaded app.
+* All public methods are thread-safe: a single mutex guards all internal state.
 */
 template<typename ObjectType>
 class UniqueIdObjectStorage {
@@ -20,36 +21,10 @@ public:
     UniqueIdObjectStorage(unsigned long maxCount = 0xFFFFFFFFu)
         : m_maxCount(maxCount)
         , m_counter(0)
+        , m_overflowed(false)
     {
-        auto getUniqueAfterOverflow = [this]() -> unsigned long {
-            auto currentId = m_counter;
-            std::unique_lock<std::mutex> lock(m_counterMutex);
-            while (m_objects.find(currentId) != m_objects.end()){
-                currentId += 1;
-                if (m_objects.size() == m_maxCount) return invalidId;
-                if (currentId == m_maxCount){
-                    currentId = 0;
-                }
-            }
-            m_counter = currentId + 1;
-            if (m_counter == m_maxCount){
-                m_counter = 0;
-            }
-            return currentId;
-        };
-
-        getUniqueId = [this, getUniqueAfterOverflow]() -> unsigned long {
-            std::unique_lock<std::mutex> lock(m_counterMutex);
-            unsigned long current_id = m_counter;
-            m_counter += 1;
-            if (m_counter == m_maxCount){
-                m_counter = 0;
-                getUniqueId = getUniqueAfterOverflow;
-            }
-            return current_id;
-        };
     }
-    
+
     /*
     * Adds an object to a storage and assigns an id for it.
     * One object is stored only once, if it already exists in the storage then no new id is generated and old one is used.
@@ -60,36 +35,35 @@ public:
     {
         auto lockedObject = object.lock();
         if (!lockedObject) return invalidId;
+
+        std::unique_lock<std::mutex> lock(m_mutex);
+
         if (m_objects.size() == m_maxCount) return invalidId;
 
-        std::unique_lock<std::mutex> lock(m_objectsMutex);
-
         auto alreadyAddedId = std::find_if(m_objects.begin(), m_objects.end(),
-            [lockedObject](auto current)
+            [lockedObject](const std::pair<const unsigned long, std::weak_ptr<ObjectType>>& current)
             {
                 return !current.second.expired() &&
                     current.second.lock() == lockedObject;
             });
         if (alreadyAddedId != m_objects.end()) return alreadyAddedId->first;
 
-        auto id = getUniqueId();
+        auto id = getUniqueIdLocked();
+        if (id == invalidId) return invalidId;
         m_objects[id] = object;
         return id;
     }
-    
+
     /*
     * Removes item from storage.
     * @param id The id of object that is to be removed from storage.
     */
     void remove(unsigned long id)
     {
-        if (m_objects.find(id) != m_objects.end())
-        {
-            std::unique_lock<std::mutex> lock(m_objectsMutex);
-            m_objects.erase(id);
-        }
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_objects.erase(id);
     }
-    
+
     /*
     * Gives access to stored object given by id.
     * @param id The id of object that should be obtained.
@@ -97,9 +71,11 @@ public:
     */
     std::weak_ptr<ObjectType> get(unsigned long id)
     {
-        if (m_objects.find(id) != m_objects.end())
+        std::unique_lock<std::mutex> lock(m_mutex);
+        auto it = m_objects.find(id);
+        if (it != m_objects.end())
         {
-            return m_objects[id];
+            return it->second;
         }
         return std::weak_ptr<ObjectType>();
     }
@@ -109,23 +85,52 @@ public:
     */
     unsigned long getInvalidId() const {return invalidId;}
 private:
+
+    /**
+    * Generates a unique id. Must be called with m_mutex held.
+    * @return A unique id or invalidId if no id is available.
+    */
+    unsigned long getUniqueIdLocked()
+    {
+        if (!m_overflowed) {
+            unsigned long current_id = m_counter;
+            m_counter += 1;
+            if (m_counter == m_maxCount) {
+                m_counter = 0;
+                m_overflowed = true;
+            }
+            return current_id;
+        }
+        // After overflow: search for an unused id
+        auto startId = m_counter;
+        while (m_objects.find(m_counter) != m_objects.end()) {
+            m_counter += 1;
+            if (m_objects.size() == m_maxCount) return invalidId;
+            if (m_counter == m_maxCount) {
+                m_counter = 0;
+            }
+            if (m_counter == startId) return invalidId;
+        }
+        unsigned long currentId = m_counter;
+        m_counter += 1;
+        if (m_counter == m_maxCount) {
+            m_counter = 0;
+        }
+        return currentId;
+    }
+
     /** invalid id */
     const unsigned long invalidId = 0xFFFFFFFFu;
-    /*
-    * A function that generates id.
-    * @returns the unique id to be used among m_objects.
-    */
-    std::function<unsigned long(void)> getUniqueId;
     /* Maximum number of objects hold by this storage. */
     const unsigned long m_maxCount;
-    
+
     /* Object stored with their unique id. */
     std::unordered_map<unsigned long, std::weak_ptr<ObjectType>> m_objects;
-    /* A mutex to guard operations on stored objects.*/
-    std::mutex m_objectsMutex;
-    
+
     /* A counter to help tracking unique id*/
     unsigned long m_counter;
-    /* A mutex to guard operations on counter.*/
-    std::mutex m_counterMutex;
+    /* Whether the counter has overflowed at least once */
+    bool m_overflowed;
+    /* A single mutex to guard all mutable state */
+    std::mutex m_mutex;
 };

--- a/src/olink/remoteregistry.cpp
+++ b/src/olink/remoteregistry.cpp
@@ -153,6 +153,7 @@ unsigned long RemoteRegistry::registerNode(std::weak_ptr<IRemoteNode> node)
     if (!lockedNode){
         static const std::string invalidNodeLog = "Trying to add node, but it is already gone. Node NOT added.";
         emitLog(LogLevel::Warning, invalidNodeLog);
+        return m_remoteNodesById.getInvalidId();
     }
     return m_remoteNodesById.add(lockedNode);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,10 +27,35 @@ add_executable(tst_olink ${TEST_OLINK_SOURCES})
 add_test(tst_olink tst_olink)
 target_link_libraries(tst_olink PRIVATE olink_core Catch2::Catch2 trompeloeil::trompeloeil)
 
-# ensure maximum compiler support
+# Defensive compiler flags for tests only — catch as much as possible early.
+# These are NOT applied to the library itself to avoid enforcing them on consumers.
 if(NOT MSVC)
-  target_compile_options(tst_olink PRIVATE -Wall -Wextra -Wpedantic -Werror -fvisibility=hidden)
+  target_compile_options(tst_olink PRIVATE
+    -Wall -Wextra -Wpedantic -Werror
+    -fvisibility=hidden
+    -Wshadow
+    -Wnon-virtual-dtor
+    -Wold-style-cast
+    -Wcast-align
+    -Wunused
+    -Woverloaded-virtual
+    -Wconversion
+    -Wsign-conversion
+    -Wnull-dereference
+    -Wdouble-promotion
+    -Wformat=2
+    -Wimplicit-fallthrough
+  )
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(tst_olink PRIVATE
+      -Wmisleading-indentation
+      -Wduplicated-cond
+      -Wduplicated-branches
+      -Wlogical-op
+      -Wuseless-cast
+    )
+  endif()
 else()
-  target_compile_options(tst_olink PRIVATE /W4 /WX PUBLIC /wd4251)
+  target_compile_options(tst_olink PRIVATE /W4 /WX /w14242 /w14254 /w14263 /w14265 /w14287 /w14296 /w14311 /w14545 /w14546 /w14547 /w14549 /w14555 /w14619 /w14640 /w14826 /w14905 /w14906 /w14928 PUBLIC /wd4251)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_OLINK_SOURCES
     test_remote_registry.cpp
     test_uniqueidstorage.cpp
     test_remote_node.cpp
+    test_thread_safety.cpp
     sinkobject.hpp
     sourceobject.hpp
     mocks.h

--- a/tests/matchers.h
+++ b/tests/matchers.h
@@ -12,9 +12,9 @@
 inline auto contains_keywords(std::vector<std::string> keywords)
 {
     return trompeloeil::make_matcher<const std::string&>(
-        [](const std::string& value, std::vector<std::string> keywords)
+        [](const std::string& value, const std::vector<std::string>& kw)
         {
-            for (auto& keyword : keywords)
+            for (const auto& keyword : kw)
             {
                 if (value.find(keyword) == std::string::npos)
                     return false;
@@ -23,10 +23,10 @@ inline auto contains_keywords(std::vector<std::string> keywords)
         },
 
         // print lambda for error message
-            [](std::ostream& os, std::vector<std::string> keywords)
+            [](std::ostream& os, const std::vector<std::string>& kw)
         {
             os << " matching contains_keywords( ";
-            for (auto& keyword : keywords)
+            for (const auto& keyword : kw)
             {
                 os << keyword << " ";
             }
@@ -34,7 +34,7 @@ inline auto contains_keywords(std::vector<std::string> keywords)
         },
 
             // stored keywords
-            std::vector<std::string>(keywords)
+            keywords
             );
 }
 
@@ -46,10 +46,10 @@ inline auto contains_keywords(std::vector<std::string> keywords)
 inline auto network_message_contains_keywords(std::vector<std::string> keywords, ApiGear::ObjectLink::MessageConverter& converter)
 {
     return trompeloeil::make_matcher<const std::string&>(
-        [&converter](const std::string& networkMessage, std::vector<std::string> keywords)
+        [&converter](const std::string& networkMessage, const std::vector<std::string>& kw)
         {
             auto translatedMessage = converter.fromString(networkMessage).dump();
-            for (auto& keyword : keywords)
+            for (const auto& keyword : kw)
             {
                 if (translatedMessage.find(keyword) == std::string::npos)
                     return false;
@@ -58,10 +58,10 @@ inline auto network_message_contains_keywords(std::vector<std::string> keywords,
         },
 
         // print lambda for error message
-            [](std::ostream& os, std::vector<std::string> keywords)
+            [](std::ostream& os, const std::vector<std::string>& kw)
         {
             os << " matching contains_keywords( ";
-            for (auto& keyword : keywords)
+            for (const auto& keyword : kw)
             {
                 os << keyword << " ";
             }
@@ -69,6 +69,6 @@ inline auto network_message_contains_keywords(std::vector<std::string> keywords,
         },
 
             // stored keywords
-            std::vector<std::string>(keywords)
+            keywords
             );
 }

--- a/tests/test_client_node.cpp
+++ b/tests/test_client_node.cpp
@@ -423,6 +423,116 @@ TEST_CASE("Client Node")
         testedNode.reset();
     }
 
+    SECTION("handling error message for pending invoke - callback called with empty value and pending entry removed")
+    {
+        registry.addSink(sink1);
+
+        const auto methodIdSink1 = ApiGear::ObjectLink::Name::createMemberId(sink1Id, methodName);
+
+        auto notSetRequestValue = 999999999;
+        auto requestId = notSetRequestValue;
+
+        // Invoke a remote method, capture the requestId assigned by the node.
+        REQUIRE_CALL(outputMock, writeMessage(network_message_contains_keywords({ methodIdSink1, exampleArguments.dump() }, converter)))
+            .LR_SIDE_EFFECT(requestId = retrieveRequestId(_1));
+
+        bool callbackCalled = false;
+        nlohmann::json receivedValue;
+        std::string receivedMethodId;
+        testedNode->invokeRemote(methodIdSink1, exampleArguments, [&](auto args){
+            callbackCalled = true;
+            receivedMethodId = args.methodId;
+            receivedValue = args.value;
+        });
+        REQUIRE(requestId != notSetRequestValue);
+
+        // Send an Error message referencing the Invoke msgType and the same requestId.
+        const auto& errorMessage = ApiGear::ObjectLink::Protocol::errorMessage(
+            ApiGear::ObjectLink::MsgType::Invoke, requestId, "test error");
+        testedNode->handleMessage(converter.toString(errorMessage));
+
+        // Verify the callback was called with empty/null json value.
+        REQUIRE(callbackCalled);
+        REQUIRE(receivedValue == nlohmann::json());
+
+        // Verify the pending invoke was cleaned up by sending an InvokeReply for the same requestId.
+        // The callback should NOT be called again since it was already removed.
+        callbackCalled = false;
+        nlohmann::json functionResult = {{ 17 }};
+        const auto& invokeReplyMessage = ApiGear::ObjectLink::Protocol::invokeReplyMessage(requestId, methodIdSink1, functionResult);
+        testedNode->handleMessage(converter.toString(invokeReplyMessage));
+        REQUIRE_FALSE(callbackCalled);
+
+        // test clean up
+        testedNode.reset();
+    }
+
+    SECTION("handling error message for InvokeReply msgType - callback called with empty value")
+    {
+        registry.addSink(sink1);
+
+        const auto methodIdSink1 = ApiGear::ObjectLink::Name::createMemberId(sink1Id, methodName);
+
+        auto notSetRequestValue = 999999999;
+        auto requestId = notSetRequestValue;
+
+        REQUIRE_CALL(outputMock, writeMessage(network_message_contains_keywords({ methodIdSink1, exampleArguments.dump() }, converter)))
+            .LR_SIDE_EFFECT(requestId = retrieveRequestId(_1));
+
+        bool callbackCalled = false;
+        testedNode->invokeRemote(methodIdSink1, exampleArguments, [&](auto /*args*/){
+            callbackCalled = true;
+        });
+        REQUIRE(requestId != notSetRequestValue);
+
+        // Send an Error message with InvokeReply msgType.
+        const auto& errorMessage = ApiGear::ObjectLink::Protocol::errorMessage(
+            ApiGear::ObjectLink::MsgType::InvokeReply, requestId, "reply error");
+        testedNode->handleMessage(converter.toString(errorMessage));
+
+        REQUIRE(callbackCalled);
+
+        // test clean up
+        testedNode.reset();
+    }
+
+    SECTION("handling error message for non-invoke msgType - no pending invoke cleanup")
+    {
+        registry.addSink(sink1);
+
+        const auto methodIdSink1 = ApiGear::ObjectLink::Name::createMemberId(sink1Id, methodName);
+
+        auto notSetRequestValue = 999999999;
+        auto requestId = notSetRequestValue;
+
+        REQUIRE_CALL(outputMock, writeMessage(network_message_contains_keywords({ methodIdSink1, exampleArguments.dump() }, converter)))
+            .LR_SIDE_EFFECT(requestId = retrieveRequestId(_1));
+
+        bool callbackCalled = false;
+        testedNode->invokeRemote(methodIdSink1, exampleArguments, [&](auto /*args*/){
+            callbackCalled = true;
+        });
+        REQUIRE(requestId != notSetRequestValue);
+
+        // Send an Error message with a non-invoke msgType (e.g. SetProperty).
+        // The pending invoke should NOT be cleaned up.
+        const auto& errorMessage = ApiGear::ObjectLink::Protocol::errorMessage(
+            ApiGear::ObjectLink::MsgType::SetProperty, requestId, "property error");
+        testedNode->handleMessage(converter.toString(errorMessage));
+
+        REQUIRE_FALSE(callbackCalled);
+
+        // The pending invoke should still be there - verify by sending the real reply.
+        callbackCalled = false;
+        nlohmann::json functionResult = {{ 17 }};
+        const auto& invokeReplyMessage = ApiGear::ObjectLink::Protocol::invokeReplyMessage(requestId, methodIdSink1, functionResult);
+        testedNode->handleMessage(converter.toString(invokeReplyMessage));
+        REQUIRE(callbackCalled);
+
+        // test clean up
+        testedNode.reset();
+    }
+
     SECTION("Messages are not sent if the write function is not set.")
     {
         // keep as ptr to destroy before going out of scope of test. The mock does not do well with expectations left in tests for test tear down.

--- a/tests/test_client_node.cpp
+++ b/tests/test_client_node.cpp
@@ -25,11 +25,11 @@ namespace {
     ApiGear::ObjectLink::MessageConverter converter(ApiGear::ObjectLink::MessageFormat::JSON);
 
     // Helper function which gets from a InvokeMessage a requestId given by clientNode.
-    int retrieveRequestId(const std::string& networkMessage)
+    unsigned int retrieveRequestId(const std::string& networkMessage)
     {
         const auto& requestMessage = converter.fromString(networkMessage);
         REQUIRE(requestMessage[0].get<int>() == static_cast<int>(ApiGear::ObjectLink::MsgType::Invoke));
-        int result = requestMessage[1].get<int>();
+        unsigned int result = requestMessage[1].get<unsigned int>();
         return result;
     };
 
@@ -162,7 +162,7 @@ TEST_CASE("Client Node")
         const auto methodIdSink2 = ApiGear::ObjectLink::Name::createMemberId(sink2Id, methodName);
 
         // Init to some value we know for sure the first requestId won't have;
-        auto notSetRequestValue = 999999999;
+        unsigned int notSetRequestValue = 999999999u;
         auto firstRequestId = notSetRequestValue;
         auto secondRequestId = notSetRequestValue;
 
@@ -214,7 +214,7 @@ TEST_CASE("Client Node")
         const auto methodIdSink1 = ApiGear::ObjectLink::Name::createMemberId(sink1Id, methodName);
 
         // Init to some value we know for sure the first requestId won't have;
-        auto notSetRequestValue = 999999999;
+        unsigned int notSetRequestValue = 999999999u;
         auto requestId = notSetRequestValue;
 
         // Prepare node to be waiting for invoke reply with requestId it creates on sending and for methodIdSink1.
@@ -246,9 +246,9 @@ TEST_CASE("Client Node")
         const auto methodIdSink2 = ApiGear::ObjectLink::Name::createMemberId(sink2Id, methodName);
 
         // Init to some value we know for sure the first requestId won't have;
-        auto notSetRequestValue = 999999999;
+        unsigned int notSetRequestValue = 999999999u;
         auto requestId = notSetRequestValue;
-        auto otherRequestId = 157;
+        unsigned int otherRequestId = 157u;
 
         // Prepare node to be waiting for invoke reply with requestId it creates on sending and for methodIdSink1.
         REQUIRE_CALL(outputMock, writeMessage(network_message_contains_keywords({ methodIdSink1, exampleArguments.dump() }, converter)))
@@ -429,7 +429,7 @@ TEST_CASE("Client Node")
 
         const auto methodIdSink1 = ApiGear::ObjectLink::Name::createMemberId(sink1Id, methodName);
 
-        auto notSetRequestValue = 999999999;
+        unsigned int notSetRequestValue = 999999999u;
         auto requestId = notSetRequestValue;
 
         // Invoke a remote method, capture the requestId assigned by the node.
@@ -448,7 +448,7 @@ TEST_CASE("Client Node")
 
         // Send an Error message referencing the Invoke msgType and the same requestId.
         const auto& errorMessage = ApiGear::ObjectLink::Protocol::errorMessage(
-            ApiGear::ObjectLink::MsgType::Invoke, requestId, "test error");
+            ApiGear::ObjectLink::MsgType::Invoke, static_cast<int>(requestId), "test error");
         testedNode->handleMessage(converter.toString(errorMessage));
 
         // Verify the callback was called with empty/null json value.
@@ -473,7 +473,7 @@ TEST_CASE("Client Node")
 
         const auto methodIdSink1 = ApiGear::ObjectLink::Name::createMemberId(sink1Id, methodName);
 
-        auto notSetRequestValue = 999999999;
+        unsigned int notSetRequestValue = 999999999u;
         auto requestId = notSetRequestValue;
 
         REQUIRE_CALL(outputMock, writeMessage(network_message_contains_keywords({ methodIdSink1, exampleArguments.dump() }, converter)))
@@ -487,7 +487,7 @@ TEST_CASE("Client Node")
 
         // Send an Error message with InvokeReply msgType.
         const auto& errorMessage = ApiGear::ObjectLink::Protocol::errorMessage(
-            ApiGear::ObjectLink::MsgType::InvokeReply, requestId, "reply error");
+            ApiGear::ObjectLink::MsgType::InvokeReply, static_cast<int>(requestId), "reply error");
         testedNode->handleMessage(converter.toString(errorMessage));
 
         REQUIRE(callbackCalled);
@@ -502,7 +502,7 @@ TEST_CASE("Client Node")
 
         const auto methodIdSink1 = ApiGear::ObjectLink::Name::createMemberId(sink1Id, methodName);
 
-        auto notSetRequestValue = 999999999;
+        unsigned int notSetRequestValue = 999999999u;
         auto requestId = notSetRequestValue;
 
         REQUIRE_CALL(outputMock, writeMessage(network_message_contains_keywords({ methodIdSink1, exampleArguments.dump() }, converter)))
@@ -517,7 +517,7 @@ TEST_CASE("Client Node")
         // Send an Error message with a non-invoke msgType (e.g. SetProperty).
         // The pending invoke should NOT be cleaned up.
         const auto& errorMessage = ApiGear::ObjectLink::Protocol::errorMessage(
-            ApiGear::ObjectLink::MsgType::SetProperty, requestId, "property error");
+            ApiGear::ObjectLink::MsgType::SetProperty, static_cast<int>(requestId), "property error");
         testedNode->handleMessage(converter.toString(errorMessage));
 
         REQUIRE_FALSE(callbackCalled);

--- a/tests/test_client_registry.cpp
+++ b/tests/test_client_registry.cpp
@@ -144,4 +144,35 @@ TEST_CASE("client registry")
     {
         clientRegistry.removeSink("some otherId");
     }
+
+    SECTION("setNode without prior addSink stores nodeId correctly")
+    {
+        // Create a dummy node first to consume ID 0, so the real node gets a non-zero ID.
+        // This ensures the test catches the bug where nodeId defaults to 0 after
+        // value-initialization of SinkToClientEntry.
+        auto dummyNode = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
+        (void)dummyNode;
+
+        std::string unknownObjectId = "tests.unknownObject";
+        auto node1 = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
+        auto nodeId1 = node1->getNodeId();
+
+        clientRegistry.setNode(nodeId1, unknownObjectId);
+
+        auto retrievedNode = clientRegistry.getNode(unknownObjectId).lock();
+        REQUIRE(retrievedNode == node1);
+    }
+
+    SECTION("registerNode with expired node returns invalidId")
+    {
+        std::weak_ptr<ApiGear::ObjectLink::IClientNode> expiredWeak;
+        {
+            auto tempNode = ApiGear::ObjectLink::ClientNode::create(clientRegistry);
+            expiredWeak = tempNode;
+        }
+        // expiredWeak is now expired
+        auto result = clientRegistry.registerNode(expiredWeak);
+        // Should return invalidId since the node is expired
+        REQUIRE(result == 0xFFFFFFFFu);
+    }
 }

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -2,6 +2,7 @@
 
 #include "olink/core/types.h"
 #include "olink/core/protocol.h"
+#include "olink/core/basenode.h"
 
 #include <string>
 #include "nlohmann/json.hpp"
@@ -74,5 +75,239 @@ TEST_CASE("protocol")
         REQUIRE(msg[1] == msgType);
         REQUIRE(msg[2] == requestId);
         REQUIRE(msg[3] == error);
+    }
+}
+
+// Stub listener that records nothing — we only care that handleMessage returns false
+// for truncated messages, not that listener methods are called.
+class StubProtocolListener : public IProtocolListener {
+public:
+    void handleLink(const std::string& /*objectId*/) override {}
+    void handleUnlink(const std::string& /*objectId*/) override {}
+    void handleInit(const std::string& /*objectId*/, const nlohmann::json& /*props*/) override {}
+    void handleSetProperty(const std::string& /*propertyId*/, const nlohmann::json& /*value*/) override {}
+    void handlePropertyChange(const std::string& /*propertyId*/, const nlohmann::json& /*value*/) override {}
+    void handleInvoke(unsigned int /*requestId*/, const std::string& /*methodId*/, const nlohmann::json& /*args*/) override {}
+    void handleInvokeReply(unsigned int /*requestId*/, const std::string& /*methodId*/, const nlohmann::json& /*value*/) override {}
+    void handleSignal(const std::string& /*signalId*/, const nlohmann::json& /*args*/) override {}
+    void handleError(int /*msgType*/, int /*requestId*/, const std::string& /*error*/) override {}
+};
+
+TEST_CASE("handleMessage truncated messages", "[Protocol]")
+{
+    Protocol protocol;
+    StubProtocolListener listener;
+
+    SECTION("non-array message returns false") {
+        json msg = "not an array";
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+    }
+
+    SECTION("empty array returns false") {
+        json msg = json::array();
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+    }
+
+    SECTION("truncated Link message") {
+        json msg = json::array({ MsgType::Link });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+
+    SECTION("truncated Init message - missing props") {
+        json msg = json::array({ MsgType::Init, "demo.Calc" });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+
+    SECTION("truncated Init message - missing objectId and props") {
+        json msg = json::array({ MsgType::Init });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+
+    SECTION("truncated Unlink message") {
+        json msg = json::array({ MsgType::Unlink });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+
+    SECTION("truncated SetProperty message") {
+        json msg = json::array({ MsgType::SetProperty, "demo.Calc/count" });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+
+    SECTION("truncated PropertyChange message") {
+        json msg = json::array({ MsgType::PropertyChange, "demo.Calc/count" });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+
+    SECTION("truncated Invoke message - missing args") {
+        json msg = json::array({ MsgType::Invoke, 1, "demo.Calc/add" });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+
+    SECTION("truncated Invoke message - only type") {
+        json msg = json::array({ MsgType::Invoke });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+
+    SECTION("truncated InvokeReply message") {
+        json msg = json::array({ MsgType::InvokeReply, 1 });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+
+    SECTION("truncated Signal message") {
+        json msg = json::array({ MsgType::Signal });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+
+    SECTION("truncated Error message") {
+        json msg = json::array({ MsgType::Error, 30 });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+}
+
+// Helper concrete BaseNode for testing — BaseNode is not abstract for handleMessage
+class TestableBaseNode : public BaseNode {
+public:
+    bool loggedError = false;
+    std::string lastLogMessage;
+
+    TestableBaseNode() {
+        onLog([this](LogLevel level, const std::string& msg) {
+            if (level == LogLevel::Error) {
+                loggedError = true;
+            }
+            lastLogMessage = msg;
+        });
+        setLogLevel(LogLevel::Info);
+    }
+};
+
+TEST_CASE("handleMessage type mismatch", "[Protocol]")
+{
+    Protocol protocol;
+    StubProtocolListener listener;
+
+    SECTION("Link with integer instead of string objectId") {
+        json msg = json::array({ MsgType::Link, 42 });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+
+    SECTION("Invoke with string instead of unsigned int requestId") {
+        json msg = json::array({ MsgType::Invoke, "not-an-int", "method", json::array() });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+
+    SECTION("Init with integer instead of string objectId") {
+        json msg = json::array({ MsgType::Init, 42, json::object() });
+        REQUIRE_FALSE(protocol.handleMessage(msg, listener));
+        REQUIRE_FALSE(protocol.lastError().empty());
+    }
+}
+
+TEST_CASE("BaseNode::handleMessage with invalid data", "[BaseNode]")
+{
+    TestableBaseNode node;
+
+    SECTION("invalid JSON does not crash") {
+        REQUIRE_NOTHROW(node.handleMessage("this is not json{{{"));
+    }
+
+    SECTION("invalid JSON is handled gracefully") {
+        // Should not crash or throw; the invalid input is silently rejected
+        node.handleMessage("this is not json{{{");
+        // No crash means success - the empty json from fromString
+        // is handled by Protocol::handleMessage returning false
+    }
+
+    SECTION("empty string does not crash") {
+        REQUIRE_NOTHROW(node.handleMessage(""));
+    }
+
+    SECTION("valid but non-array JSON does not crash") {
+        REQUIRE_NOTHROW(node.handleMessage("42"));
+    }
+
+    SECTION("truncated message does not crash") {
+        // A valid JSON array but truncated protocol message
+        REQUIRE_NOTHROW(node.handleMessage("[10]"));
+    }
+
+    SECTION("type mismatch in message logs error via catch") {
+        // This triggers the try-catch in BaseNode because Protocol::handleMessage
+        // re-throws type_error as false return, but the BaseNode catch is a safety net
+        // For invalid JSON, the non-throwing parse handles it silently
+        // For type mismatches, Protocol now catches them internally
+        // Just verify no crash occurs
+        node.handleMessage("[10, 42]");  // Link with int instead of string
+    }
+
+    SECTION("setMaxMessageSize forwards to converter") {
+        node.setMaxMessageSize(10);
+        std::string longMsg = "[10, \"demo.Calc\"]";  // > 10 bytes
+        node.handleMessage(longMsg);
+        // Message rejected silently by converter, protocol sees empty json
+        // No crash is the success criterion
+    }
+}
+
+TEST_CASE("MessageConverter::fromString with invalid data", "[MessageConverter]")
+{
+    MessageConverter converter(MessageFormat::JSON);
+
+    SECTION("invalid JSON returns empty json without throwing") {
+        nlohmann::json result;
+        REQUIRE_NOTHROW(result = converter.fromString("not valid json"));
+        REQUIRE(result.empty());
+    }
+
+    SECTION("empty string returns empty json without throwing") {
+        nlohmann::json result;
+        REQUIRE_NOTHROW(result = converter.fromString(""));
+        REQUIRE(result.empty());
+    }
+}
+
+TEST_CASE("MessageConverter message size limit", "[MessageConverter]")
+{
+    MessageConverter converter(MessageFormat::JSON);
+
+    SECTION("message within default limit parses correctly") {
+        std::string validMsg = "[10, \"demo.Calc\"]";
+        nlohmann::json result = converter.fromString(validMsg);
+        REQUIRE(result.is_array());
+        REQUIRE(result.size() == 2);
+    }
+
+    SECTION("message exceeding custom limit returns empty json") {
+        converter.setMaxMessageSize(10);
+        std::string longMsg = "[10, \"demo.Calc\"]";  // > 10 bytes
+        nlohmann::json result = converter.fromString(longMsg);
+        REQUIRE(result.empty());
+    }
+
+    SECTION("setMaxMessageSize works") {
+        converter.setMaxMessageSize(5);
+        // Even valid JSON is rejected if too large
+        nlohmann::json result = converter.fromString("[10, \"x\"]");
+        REQUIRE(result.empty());
+    }
+
+    SECTION("message exactly at limit parses correctly") {
+        std::string msg = "[10]";
+        converter.setMaxMessageSize(msg.size());
+        nlohmann::json result = converter.fromString(msg);
+        REQUIRE(result.is_array());
     }
 }

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -70,7 +70,7 @@ TEST_CASE("protocol")
         REQUIRE(msg[2] == args);
     }
     SECTION("error") {
-        json msg = Protocol::errorMessage(msgType, requestId, error);
+        json msg = Protocol::errorMessage(msgType, static_cast<int>(requestId), error);
         REQUIRE(msg[0] == MsgType::Error);
         REQUIRE(msg[1] == msgType);
         REQUIRE(msg[2] == requestId);

--- a/tests/test_remote_node.cpp
+++ b/tests/test_remote_node.cpp
@@ -153,8 +153,8 @@ TEST_CASE("Remote Node")
         auto methodId1 = ApiGear::ObjectLink::Name::createMemberId(source1Id, methodName);
         auto methodId2 = ApiGear::ObjectLink::Name::createMemberId(source2Id, methodName);
 
-        int requestId1 = 189;
-        int requestId2 = 32;
+        unsigned int requestId1 = 189u;
+        unsigned int requestId2 = 32u;
 
         auto invokeMethod1 = converter.toString(ApiGear::ObjectLink::Protocol::invokeMessage(requestId1, methodId1, exampleArguments));
         auto invokeMethod2 = converter.toString(ApiGear::ObjectLink::Protocol::invokeMessage(requestId2, methodId2, exampleArguments));

--- a/tests/test_remote_registry.cpp
+++ b/tests/test_remote_registry.cpp
@@ -138,4 +138,17 @@ TEST_CASE("server registry simple tests without threads")
     {
         registry.removeSource("some otherId");
     }
+
+    SECTION("registerNode with expired node returns invalidId")
+    {
+        std::weak_ptr<ApiGear::ObjectLink::IRemoteNode> expiredWeak;
+        {
+            auto tempNode = ApiGear::ObjectLink::RemoteNode::createRemoteNode(registry);
+            expiredWeak = tempNode;
+        }
+        // expiredWeak is now expired
+        auto result = registry.registerNode(expiredWeak);
+        // Should return invalidId since the node is expired
+        REQUIRE(result == 0xFFFFFFFFu);
+    }
 }

--- a/tests/test_thread_safety.cpp
+++ b/tests/test_thread_safety.cpp
@@ -23,22 +23,22 @@ class StorageTestObject {};
 TEST_CASE("UniqueIdObjectStorage concurrent add/remove/get", "[ThreadSafety][UniqueIdObjectStorage]")
 {
     UniqueIdObjectStorage<StorageTestObject> storage(100);
-    constexpr int numThreads = 8;
-    constexpr int opsPerThread = 50;
+    constexpr std::size_t numThreads = 8;
+    constexpr std::size_t opsPerThread = 50;
 
     // Create shared objects to add
     std::vector<std::shared_ptr<StorageTestObject>> objects;
-    for (int i = 0; i < numThreads * opsPerThread; ++i) {
+    for (std::size_t i = 0; i < numThreads * opsPerThread; ++i) {
         objects.push_back(std::make_shared<StorageTestObject>());
     }
 
     SECTION("concurrent adds produce unique, valid ids")
     {
         std::vector<std::future<std::vector<unsigned long>>> futures;
-        for (int t = 0; t < numThreads; ++t) {
+        for (std::size_t t = 0; t < numThreads; ++t) {
             futures.push_back(std::async(std::launch::async, [&, t]() {
                 std::vector<unsigned long> ids;
-                for (int i = 0; i < opsPerThread; ++i) {
+                for (std::size_t i = 0; i < opsPerThread; ++i) {
                     auto id = storage.add(objects[t * opsPerThread + i]);
                     ids.push_back(id);
                 }
@@ -65,13 +65,13 @@ TEST_CASE("UniqueIdObjectStorage concurrent add/remove/get", "[ThreadSafety][Uni
     {
         // Pre-add some objects
         std::vector<unsigned long> preAddedIds;
-        for (int i = 0; i < 20; ++i) {
+        for (std::size_t i = 0; i < 20; ++i) {
             preAddedIds.push_back(storage.add(objects[i]));
         }
 
         // Concurrently add new objects and remove existing ones
         auto adderFuture = std::async(std::launch::async, [&]() {
-            for (int i = 20; i < 60; ++i) {
+            for (std::size_t i = 20; i < 60; ++i) {
                 storage.add(objects[i]);
             }
         });

--- a/tests/test_thread_safety.cpp
+++ b/tests/test_thread_safety.cpp
@@ -1,0 +1,281 @@
+#include <catch2/catch.hpp>
+
+#include "olink/core/uniqueidobjectstorage.h"
+#include "olink/core/basenode.h"
+#include "olink/core/types.h"
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <future>
+#include <vector>
+#include <atomic>
+#include <set>
+
+using namespace ApiGear::ObjectLink;
+
+// =====================================================================
+// UniqueIdObjectStorage thread safety tests
+// =====================================================================
+
+class StorageTestObject {};
+
+TEST_CASE("UniqueIdObjectStorage concurrent add/remove/get", "[ThreadSafety][UniqueIdObjectStorage]")
+{
+    UniqueIdObjectStorage<StorageTestObject> storage(100);
+    constexpr int numThreads = 8;
+    constexpr int opsPerThread = 50;
+
+    // Create shared objects to add
+    std::vector<std::shared_ptr<StorageTestObject>> objects;
+    for (int i = 0; i < numThreads * opsPerThread; ++i) {
+        objects.push_back(std::make_shared<StorageTestObject>());
+    }
+
+    SECTION("concurrent adds produce unique, valid ids")
+    {
+        std::vector<std::future<std::vector<unsigned long>>> futures;
+        for (int t = 0; t < numThreads; ++t) {
+            futures.push_back(std::async(std::launch::async, [&, t]() {
+                std::vector<unsigned long> ids;
+                for (int i = 0; i < opsPerThread; ++i) {
+                    auto id = storage.add(objects[t * opsPerThread + i]);
+                    ids.push_back(id);
+                }
+                return ids;
+            }));
+        }
+
+        std::set<unsigned long> allIds;
+        for (auto& f : futures) {
+            auto ids = f.get();
+            for (auto id : ids) {
+                if (id != storage.getInvalidId()) {
+                    REQUIRE(allIds.find(id) == allIds.end());
+                    allIds.insert(id);
+                }
+            }
+        }
+        // All objects should have been added (100 slots, 400 objects attempted)
+        // At least the first 100 should succeed
+        REQUIRE(allIds.size() == 100);
+    }
+
+    SECTION("concurrent add and remove")
+    {
+        // Pre-add some objects
+        std::vector<unsigned long> preAddedIds;
+        for (int i = 0; i < 20; ++i) {
+            preAddedIds.push_back(storage.add(objects[i]));
+        }
+
+        // Concurrently add new objects and remove existing ones
+        auto adderFuture = std::async(std::launch::async, [&]() {
+            for (int i = 20; i < 60; ++i) {
+                storage.add(objects[i]);
+            }
+        });
+
+        auto removerFuture = std::async(std::launch::async, [&]() {
+            for (auto id : preAddedIds) {
+                storage.remove(id);
+            }
+        });
+
+        auto getterFuture = std::async(std::launch::async, [&]() {
+            for (auto id : preAddedIds) {
+                // get() should not crash, result may be expired or valid
+                storage.get(id);
+            }
+        });
+
+        adderFuture.get();
+        removerFuture.get();
+        getterFuture.get();
+
+        // Removed objects should be gone
+        for (auto id : preAddedIds) {
+            REQUIRE(storage.get(id).expired());
+        }
+    }
+}
+
+// =====================================================================
+// BaseNode thread safety tests
+// =====================================================================
+
+TEST_CASE("BaseNode concurrent emitWrite and onWrite", "[ThreadSafety][BaseNode]")
+{
+    // BaseNode is abstract via IProtocolListener, but we can use it directly
+    // since the handler methods have default implementations
+    struct TestNode : public BaseNode {};
+
+    auto node = std::make_shared<TestNode>();
+    std::atomic<int> writeCount{0};
+
+    SECTION("concurrent emitWrite does not crash")
+    {
+        node->onWrite([&writeCount](const std::string&) {
+            ++writeCount;
+        });
+
+        std::vector<std::future<void>> futures;
+        for (int t = 0; t < 4; ++t) {
+            futures.push_back(std::async(std::launch::async, [&]() {
+                for (int i = 0; i < 50; ++i) {
+                    nlohmann::json msg = {10, "obj1"};
+                    node->emitWrite(msg);
+                }
+            }));
+        }
+        for (auto& f : futures) {
+            f.get();
+        }
+        REQUIRE(writeCount == 200);
+    }
+
+    SECTION("changing write function while emitting does not crash")
+    {
+        std::atomic<int> funcACount{0};
+        std::atomic<int> funcBCount{0};
+
+        node->onWrite([&funcACount](const std::string&) {
+            ++funcACount;
+        });
+
+        auto writerFuture = std::async(std::launch::async, [&]() {
+            for (int i = 0; i < 100; ++i) {
+                nlohmann::json msg = {10, "obj1"};
+                node->emitWrite(msg);
+            }
+        });
+
+        auto swapFuture = std::async(std::launch::async, [&]() {
+            for (int i = 0; i < 50; ++i) {
+                node->onWrite([&funcBCount](const std::string&) {
+                    ++funcBCount;
+                });
+                node->onWrite([&funcACount](const std::string&) {
+                    ++funcACount;
+                });
+            }
+        });
+
+        writerFuture.get();
+        swapFuture.get();
+        // Both counts together should equal 100
+        REQUIRE(funcACount + funcBCount == 100);
+    }
+
+    SECTION("concurrent handleMessage and setMessageFormat does not crash")
+    {
+        node->onWrite([](const std::string&) {});
+
+        auto handleFuture = std::async(std::launch::async, [&]() {
+            for (int i = 0; i < 50; ++i) {
+                // An invalid message, but it should not crash
+                node->handleMessage("[]");
+            }
+        });
+
+        auto formatFuture = std::async(std::launch::async, [&]() {
+            for (int i = 0; i < 50; ++i) {
+                node->setMessageFormat(MessageFormat::JSON);
+            }
+        });
+
+        handleFuture.get();
+        formatFuture.get();
+        // No crash = success
+    }
+}
+
+// =====================================================================
+// LoggerBase thread safety tests
+// =====================================================================
+
+TEST_CASE("LoggerBase concurrent logging", "[ThreadSafety][LoggerBase]")
+{
+    struct TestLogger : public LoggerBase {};
+
+    TestLogger logger;
+    std::atomic<int> logCount{0};
+
+    SECTION("concurrent emitLog does not crash")
+    {
+        logger.onLog([&logCount](LogLevel, const std::string&) {
+            ++logCount;
+        });
+        logger.setLogLevel(LogLevel::Info);
+
+        std::vector<std::future<void>> futures;
+        for (int t = 0; t < 4; ++t) {
+            futures.push_back(std::async(std::launch::async, [&]() {
+                for (int i = 0; i < 50; ++i) {
+                    logger.emitLog(LogLevel::Info, std::string("test msg"));
+                }
+            }));
+        }
+        for (auto& f : futures) {
+            f.get();
+        }
+        REQUIRE(logCount == 200);
+    }
+
+    SECTION("changing log function while emitting does not crash")
+    {
+        std::atomic<int> funcACount{0};
+        std::atomic<int> funcBCount{0};
+
+        logger.onLog([&funcACount](LogLevel, const std::string&) {
+            ++funcACount;
+        });
+        logger.setLogLevel(LogLevel::Info);
+
+        auto logFuture = std::async(std::launch::async, [&]() {
+            for (int i = 0; i < 100; ++i) {
+                logger.emitLog(LogLevel::Info, std::string("msg"));
+            }
+        });
+
+        auto swapFuture = std::async(std::launch::async, [&]() {
+            for (int i = 0; i < 50; ++i) {
+                logger.onLog([&funcBCount](LogLevel, const std::string&) {
+                    ++funcBCount;
+                });
+                logger.onLog([&funcACount](LogLevel, const std::string&) {
+                    ++funcACount;
+                });
+            }
+        });
+
+        logFuture.get();
+        swapFuture.get();
+        REQUIRE(funcACount + funcBCount == 100);
+    }
+
+    SECTION("changing log level while emitting does not crash")
+    {
+        logger.onLog([&logCount](LogLevel, const std::string&) {
+            ++logCount;
+        });
+        logger.setLogLevel(LogLevel::Info);
+
+        auto logFuture = std::async(std::launch::async, [&]() {
+            for (int i = 0; i < 100; ++i) {
+                logger.emitLog(LogLevel::Info, std::string("msg"));
+            }
+        });
+
+        auto levelFuture = std::async(std::launch::async, [&]() {
+            for (int i = 0; i < 50; ++i) {
+                logger.setLogLevel(LogLevel::Error);
+                logger.setLogLevel(LogLevel::Info);
+            }
+        });
+
+        logFuture.get();
+        levelFuture.get();
+        // Some logs may be skipped due to level changes, but no crash
+    }
+}

--- a/tests/test_uniqueidstorage.cpp
+++ b/tests/test_uniqueidstorage.cpp
@@ -108,6 +108,84 @@ TEST_CASE("storage")
         REQUIRE(storage.get(id4).expired() == true);
     }
 
+    SECTION("purgeExpired removes expired weak_ptrs")
+    {
+        auto id1 = storage.add(obj1);
+        auto id2 = storage.add(obj2);
+        auto id3 = storage.add(obj3);
+        REQUIRE(id1 != storage.getInvalidId());
+        REQUIRE(id2 != storage.getInvalidId());
+        REQUIRE(id3 != storage.getInvalidId());
+
+        // Storage has 3 of 5 slots used. Let obj2 expire.
+        obj2.reset();
+        REQUIRE(storage.get(id2).expired());
+
+        // purgeExpired should remove the expired entry.
+        storage.purgeExpired();
+
+        // The expired entry is gone, but the valid ones remain.
+        REQUIRE(storage.get(id1).lock() == obj1);
+        REQUIRE(storage.get(id2).expired());
+        REQUIRE(storage.get(id3).lock() == obj3);
+    }
+
+    SECTION("purgeExpired allows adding to previously full storage")
+    {
+        unsigned long smallMax = 3;
+        UniqueIdObjectStorage<MyTestObject> smallStorage(smallMax);
+
+        auto a = std::make_shared<MyTestObject>();
+        auto b = std::make_shared<MyTestObject>();
+        auto c = std::make_shared<MyTestObject>();
+        auto d = std::make_shared<MyTestObject>();
+
+        auto idA = smallStorage.add(a);
+        auto idB = smallStorage.add(b);
+        auto idC = smallStorage.add(c);
+        REQUIRE(idA != smallStorage.getInvalidId());
+        REQUIRE(idB != smallStorage.getInvalidId());
+        REQUIRE(idC != smallStorage.getInvalidId());
+
+        // Storage is full - adding should fail.
+        auto idFail = smallStorage.add(d);
+        REQUIRE(idFail == smallStorage.getInvalidId());
+
+        // Let one expire.
+        b.reset();
+        REQUIRE(smallStorage.get(idB).expired());
+
+        // Explicit purge, then add.
+        smallStorage.purgeExpired();
+        auto idD = smallStorage.add(d);
+        REQUIRE(idD != smallStorage.getInvalidId());
+        REQUIRE(smallStorage.get(idD).lock() == d);
+    }
+
+    SECTION("add lazily purges expired entries when storage is full")
+    {
+        unsigned long smallMax = 3;
+        UniqueIdObjectStorage<MyTestObject> smallStorage(smallMax);
+
+        auto a = std::make_shared<MyTestObject>();
+        auto b = std::make_shared<MyTestObject>();
+        auto c = std::make_shared<MyTestObject>();
+        auto d = std::make_shared<MyTestObject>();
+
+        smallStorage.add(a);
+        smallStorage.add(b);
+        smallStorage.add(c);
+
+        // Storage is full. Let two expire.
+        a.reset();
+        b.reset();
+
+        // add() should lazily purge and succeed without explicit purgeExpired().
+        auto idD = smallStorage.add(d);
+        REQUIRE(idD != smallStorage.getInvalidId());
+        REQUIRE(smallStorage.get(idD).lock() == d);
+    }
+
     SECTION("Multithreaded adding and remove")
     {
         auto id1 = storage.add(obj1);


### PR DESCRIPTION
## Summary

- Prevent crashes from malformed network messages (input validation,
  exception safety, configurable max message size)
- Fix thread safety in UniqueIdObjectStorage, BaseNode, and LoggerBase
- Fix ClientRegistry::setNode() dead write and registerNode() null
  node handling
- Clean up pending invoke callbacks on error, add weak_ptr purging
- Add ThreadSanitizer and AddressSanitizer CI jobs

## Details

Addresses 11 findings from a functional safety and network protocol
investigation. All fixes are wire-protocol-compatible — no changes
to message formats or cross-language behavior. No public API signature
changes (only additions: `setMaxMessageSize`, `purgeExpired`).

16 files changed, +1010 / -74 lines, 540 test assertions (was 376).

## Test plan

- [x] Full test suite passes (540 assertions in 18 test cases)
- [x] ThreadSanitizer: zero warnings
- [x] AddressSanitizer: zero warnings
- [x] CI runs on macOS, Ubuntu, Windows
- [x] CI sanitizer jobs added (ubuntu-latest)