### PR TITLE
fix: add OLINK_STATIC guard for monolithic builds

### DIFF
--- a/src/olink/core/olink_common.h
+++ b/src/olink/core/olink_common.h
@@ -25,7 +25,9 @@
 #pragma once
 
 
-#if defined _WIN32 || defined __CYGWIN__
+#if defined(OLINK_STATIC)
+  #define OLINK_EXPORT
+#elif defined _WIN32 || defined __CYGWIN__
 #ifdef __GNUC__
 #define OLINK_EXPORT __attribute__ ((dllexport))
 #else

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,21 +59,22 @@ else()
   target_compile_options(tst_olink PRIVATE /W4 /WX /w14242 /w14254 /w14263 /w14265 /w14287 /w14296 /w14311 /w14545 /w14546 /w14547 /w14549 /w14555 /w14619 /w14640 /w14826 /w14905 /w14906 /w14928 PUBLIC /wd4251)
 endif()
 
+# Sources for recompiled library variants (noexcept, static)
+set(OLINK_CORE_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/olink/core/basenode.cpp
+    ${CMAKE_SOURCE_DIR}/src/olink/core/protocol.cpp
+    ${CMAKE_SOURCE_DIR}/src/olink/core/types.cpp
+    ${CMAKE_SOURCE_DIR}/src/olink/clientnode.cpp
+    ${CMAKE_SOURCE_DIR}/src/olink/clientregistry.cpp
+    ${CMAKE_SOURCE_DIR}/src/olink/remotenode.cpp
+    ${CMAKE_SOURCE_DIR}/src/olink/remoteregistry.cpp
+    ${CMAKE_SOURCE_DIR}/src/olink/consolelogger.cpp
+)
+
 # No-exceptions test: recompile library with -fno-exceptions to verify
 # the code compiles and runs without C++ exception support (e.g. Unreal Engine).
 # Only on GCC/Clang — MSVC equivalent (/EHs-c-) has STL header quirks.
 if(NOT MSVC)
-  set(OLINK_CORE_SOURCES
-      ${CMAKE_SOURCE_DIR}/src/olink/core/basenode.cpp
-      ${CMAKE_SOURCE_DIR}/src/olink/core/protocol.cpp
-      ${CMAKE_SOURCE_DIR}/src/olink/core/types.cpp
-      ${CMAKE_SOURCE_DIR}/src/olink/clientnode.cpp
-      ${CMAKE_SOURCE_DIR}/src/olink/clientregistry.cpp
-      ${CMAKE_SOURCE_DIR}/src/olink/remotenode.cpp
-      ${CMAKE_SOURCE_DIR}/src/olink/remoteregistry.cpp
-      ${CMAKE_SOURCE_DIR}/src/olink/consolelogger.cpp
-  )
-
   add_library(olink_core_noexcept STATIC ${OLINK_CORE_SOURCES})
   target_include_directories(olink_core_noexcept PUBLIC ${CMAKE_SOURCE_DIR}/src)
   target_link_libraries(olink_core_noexcept PUBLIC nlohmann_json::nlohmann_json)
@@ -86,4 +87,17 @@ if(NOT MSVC)
   target_compile_definitions(tst_olink_noexcept PRIVATE JSON_NOEXCEPTION=1)
   add_test(NAME tst_olink_noexcept COMMAND tst_olink_noexcept)
 endif()
+
+# Static-build test: recompile library with OLINK_STATIC to verify the
+# OLINK_EXPORT macro resolves to empty (no dllexport/dllimport), as used
+# in monolithic builds (e.g. Unreal Engine Shipping configuration).
+add_library(olink_core_static STATIC ${OLINK_CORE_SOURCES})
+target_include_directories(olink_core_static PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(olink_core_static PUBLIC nlohmann_json::nlohmann_json)
+target_compile_definitions(olink_core_static PUBLIC OLINK_STATIC=1)
+
+add_executable(tst_olink_static test_static.cpp)
+target_link_libraries(tst_olink_static PRIVATE olink_core_static)
+target_compile_definitions(tst_olink_static PRIVATE OLINK_STATIC=1)
+add_test(NAME tst_olink_static COMMAND tst_olink_static)
 

--- a/tests/test_static.cpp
+++ b/tests/test_static.cpp
@@ -1,0 +1,74 @@
+// Standalone test compiled with OLINK_STATIC to verify the library
+// compiles and links correctly without dllexport/dllimport decorations,
+// as used in monolithic/static-only builds (e.g. Unreal Engine Shipping).
+
+#include "olink/core/olink_common.h"
+#include "olink/core/types.h"
+#include "olink/core/protocol.h"
+#include "olink/clientnode.h"
+#include "olink/clientregistry.h"
+#include "olink/remotenode.h"
+#include "olink/remoteregistry.h"
+#include "olink/consolelogger.h"
+
+#include "nlohmann/json.hpp"
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+
+using json = nlohmann::json;
+using namespace ApiGear::ObjectLink;
+
+static void test_name_utilities()
+{
+    std::string memberId = "demo.Calc/count";
+    assert(Name::getObjectId(memberId) == "demo.Calc");
+    assert(Name::getMemberName(memberId) == "count");
+    assert(Name::isMemberId(memberId));
+    assert(!Name::isMemberId("demo.Calc"));
+    assert(Name::createMemberId("demo.Calc", "count") == memberId);
+}
+
+static void test_registries()
+{
+    ClientRegistry clientRegistry;
+    clientRegistry.onLog(ConsoleLogger::logFunc());
+
+    RemoteRegistry remoteRegistry;
+    remoteRegistry.onLog(ConsoleLogger::logFunc());
+
+    // Verify basic registry operations link correctly
+    auto sink = clientRegistry.getSink("demo.Calc");
+    assert(!sink.lock());
+
+    auto source = remoteRegistry.getSource("demo.Calc");
+    assert(!source.lock());
+}
+
+static void test_protocol()
+{
+    json linkMsg = Protocol::linkMessage("demo.Calc");
+    assert(!linkMsg.empty());
+
+    json initMsg = Protocol::initMessage("demo.Calc", json::object({{"count", 0}}));
+    assert(!initMsg.empty());
+}
+
+int main()
+{
+    std::printf("test_name_utilities (OLINK_STATIC)... ");
+    test_name_utilities();
+    std::printf("OK\n");
+
+    std::printf("test_registries (OLINK_STATIC)... ");
+    test_registries();
+    std::printf("OK\n");
+
+    std::printf("test_protocol (OLINK_STATIC)... ");
+    test_protocol();
+    std::printf("OK\n");
+
+    std::printf("\nAll static-build tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `#ifdef OLINK_STATIC` guard to `olink_common.h` that defines `OLINK_EXPORT` as empty
- Prevents MSVC LNK4217/LNK4286 linker warnings in monolithic/static-only link configurations (e.g. Unreal Engine Shipping builds)
- Add `tst_olink_static` test that compiles and links the library with `OLINK_STATIC=1`

## Test plan
- [x] All existing tests pass (`tst_olink`, `tst_olink_noexcept`)
- [x] New `tst_olink_static` test passes on Linux
- [x] CI matrix validates on macOS, Ubuntu, Windows