### PR TITLE
chore: add uniform SPDX headers and update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2021 ApiGear
+Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+Copyright (c) 2022-2026 Epic Games, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ Unit tests on Windows, MacOS, Linux: ![Unit test results](https://github.com/api
 
 * **We generally assume that this library is built from source.**
 * Otherwise, it has to be ensured that for each build configuration the compiler version etc. matches the one which originally built the library.
+
+## License
+
+Licensed under the [MIT License](./LICENSE). See [LICENSE](./LICENSE) for details.

--- a/examples/app/calcsink.cpp
+++ b/examples/app/calcsink.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include "calcsink.h"
 
 #include "olink/core/types.h"

--- a/examples/app/calcsink.h
+++ b/examples/app/calcsink.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include <QtCore>

--- a/examples/app/main.cpp
+++ b/examples/app/main.cpp
@@ -1,26 +1,7 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include <QtGui>
 #include <QtQml>
 #include "../qtolink/olinkclient.h"

--- a/examples/qtolink/olinkclient.cpp
+++ b/examples/qtolink/olinkclient.cpp
@@ -1,26 +1,7 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include "olinkclient.h"
 #include "olink/clientnode.h"
 #include "olink/clientregistry.h"

--- a/examples/qtolink/olinkclient.h
+++ b/examples/qtolink/olinkclient.h
@@ -1,26 +1,7 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include <QtCore>

--- a/examples/qtolink/olinkhost.cpp
+++ b/examples/qtolink/olinkhost.cpp
@@ -1,26 +1,7 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include "olinkhost.h"
 
 #include "olinkremote.h"

--- a/examples/qtolink/olinkhost.h
+++ b/examples/qtolink/olinkhost.h
@@ -1,26 +1,7 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include <QtCore>

--- a/examples/qtolink/olinkremote.cpp
+++ b/examples/qtolink/olinkremote.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include "olinkremote.h"
 
 

--- a/examples/qtolink/olinkremote.h
+++ b/examples/qtolink/olinkremote.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include <QtCore>

--- a/examples/server/calcsource.cpp
+++ b/examples/server/calcsource.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include "calcsource.h"
 #include "olink/remoteregistry.h"
 

--- a/examples/server/calcsource.h
+++ b/examples/server/calcsource.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 #include "olink/remotenode.h"
 #include "olink/iobjectsource.h"

--- a/examples/server/main.cpp
+++ b/examples/server/main.cpp
@@ -1,26 +1,7 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include <QtCore>
 #include "../qtolink/olinkhost.h"
 #include "olink/remotenode.h"

--- a/src/olink/clientnode.cpp
+++ b/src/olink/clientnode.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include "clientnode.h"
 #include "clientregistry.h"
 #include "iobjectsink.h"

--- a/src/olink/clientnode.h
+++ b/src/olink/clientnode.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include "core/olink_common.h"

--- a/src/olink/clientregistry.cpp
+++ b/src/olink/clientregistry.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include "clientregistry.h"
 #include "iobjectsink.h"
 #include "iclientnode.h"

--- a/src/olink/clientregistry.h
+++ b/src/olink/clientregistry.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include "core/olink_common.h"

--- a/src/olink/consolelogger.cpp
+++ b/src/olink/consolelogger.cpp
@@ -1,26 +1,7 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include "consolelogger.h"
 #include <string>
 #include <iostream>

--- a/src/olink/consolelogger.h
+++ b/src/olink/consolelogger.h
@@ -1,26 +1,7 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include "core/types.h"

--- a/src/olink/core/basenode.cpp
+++ b/src/olink/core/basenode.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include "basenode.h"
 #include "nothrow.h"
 #include <iostream>

--- a/src/olink/core/basenode.h
+++ b/src/olink/core/basenode.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include "protocol.h"

--- a/src/olink/core/nothrow.h
+++ b/src/olink/core/nothrow.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 // Detect whether C++ exceptions are enabled.

--- a/src/olink/core/olink_common.h
+++ b/src/olink/core/olink_common.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 //
 /*
 * MIT License

--- a/src/olink/core/protocol.cpp
+++ b/src/olink/core/protocol.cpp
@@ -1,26 +1,6 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
 
 #include "protocol.h"
 #include "nothrow.h"

--- a/src/olink/core/protocol.h
+++ b/src/olink/core/protocol.h
@@ -1,26 +1,7 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include "olink_common.h"

--- a/src/olink/core/types.cpp
+++ b/src/olink/core/types.cpp
@@ -1,26 +1,7 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include "types.h"
 
 #include <string>

--- a/src/olink/core/types.h
+++ b/src/olink/core/types.h
@@ -1,26 +1,7 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include "olink_common.h"

--- a/src/olink/core/uniqueidobjectstorage.h
+++ b/src/olink/core/uniqueidobjectstorage.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include <memory>

--- a/src/olink/iclientnode.h
+++ b/src/olink/iclientnode.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include "nlohmann/json.hpp"

--- a/src/olink/iobjectsink.h
+++ b/src/olink/iobjectsink.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include "core/olink_common.h"

--- a/src/olink/iobjectsource.h
+++ b/src/olink/iobjectsource.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include "core/olink_common.h"

--- a/src/olink/iremotenode.h
+++ b/src/olink/iremotenode.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include <string>

--- a/src/olink/remotenode.cpp
+++ b/src/olink/remotenode.cpp
@@ -1,26 +1,6 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
 
 #include "remotenode.h"
 #include "remoteregistry.h"

--- a/src/olink/remotenode.h
+++ b/src/olink/remotenode.h
@@ -1,26 +1,7 @@
-/*
-* MIT License
-*
-* Copyright (c) 2021 ApiGear
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
-*/
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include "core/basenode.h"

--- a/src/olink/remoteregistry.cpp
+++ b/src/olink/remoteregistry.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include "remoteregistry.h"
 #include "iremotenode.h"
 #include "iobjectsource.h"

--- a/src/olink/remoteregistry.h
+++ b/src/olink/remoteregistry.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include "core/basenode.h"

--- a/tests/matchers.h
+++ b/tests/matchers.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include <catch2/catch.hpp>

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #pragma once
 
 #include <catch2/catch.hpp>

--- a/tests/test_client_node.cpp
+++ b/tests/test_client_node.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 
 #include <catch2/catch.hpp>
 

--- a/tests/test_client_registry.cpp
+++ b/tests/test_client_registry.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 
 #include <catch2/catch.hpp>
 #include "mocks.h"

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #if defined(__clang__)
 #pragma clang diagnostic ignored "-Wweak-vtables"
 #endif // __clang__

--- a/tests/test_noexcept.cpp
+++ b/tests/test_noexcept.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 // Standalone test compiled with -fno-exceptions to verify the library
 // compiles and works correctly without C++ exceptions.
 // Does NOT use Catch2 (which requires exceptions).

--- a/tests/test_olink.cpp
+++ b/tests/test_olink.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include <catch2/catch.hpp>
 
 #include "olink/core/protocol.h"

--- a/tests/test_protocol.cpp
+++ b/tests/test_protocol.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include <catch2/catch.hpp>
 
 #include "olink/core/types.h"

--- a/tests/test_remote_node.cpp
+++ b/tests/test_remote_node.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 
 #include <catch2/catch.hpp>
 

--- a/tests/test_remote_registry.cpp
+++ b/tests/test_remote_registry.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 
 #include <catch2/catch.hpp>
 #include "mocks.h"

--- a/tests/test_static.cpp
+++ b/tests/test_static.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 // Standalone test compiled with OLINK_STATIC to verify the library
 // compiles and links correctly without dllexport/dllimport decorations,
 // as used in monolithic/static-only builds (e.g. Unreal Engine Shipping).

--- a/tests/test_thread_safety.cpp
+++ b/tests/test_thread_safety.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include <catch2/catch.hpp>
 
 #include "olink/core/uniqueidobjectstorage.h"

--- a/tests/test_uniqueidstorage.cpp
+++ b/tests/test_uniqueidstorage.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2021-2022 ApiGear UG (haftungsbeschränkt)
+// Copyright (c) 2022-2026 Epic Games, Inc.
+
 #include <catch2/catch.hpp>
 
 #include "olink/core/uniqueidobjectstorage.h"


### PR DESCRIPTION
Adds a uniform SPDX-License-Identifier header to every source file (some files previously had a full MIT header, others none) and updates the LICENSE copyright lines for consistency. MIT is the standard license used across ApiGear projects.